### PR TITLE
Partially revert #18 to solve circular import

### DIFF
--- a/arctic_training/__init__.py
+++ b/arctic_training/__init__.py
@@ -17,32 +17,12 @@ from .logging import setup_init_logger
 
 setup_init_logger()
 
-from .callback import Callback
-from .callback import CallbackMixin
-from .checkpoint import CheckpointEngine
-from .checkpoint import DSCheckpointEngine
-from .checkpoint import HFCheckpointEngine
-from .config import BaseConfig
-from .config import CheckpointConfig
-from .config import DataConfig
-from .config import ModelConfig
-from .config import OptimizerConfig
-from .config import SchedulerConfig
-from .config import TokenizerConfig
-from .config import TrainerConfig
-from .data import DataFactory
-from .data import DataSource
-from .data import SFTDataFactory
+from .callback.callback import Callback
+from .config.base import BaseConfig
+from .config.model import ModelConfig
+from .config.trainer import TrainerConfig
 from .logging import logger
-from .model import HFModelFactory
-from .model import LigerModelFactory
-from .model import ModelFactory
-from .optimizer import FusedAdamOptimizerFactory
-from .optimizer import OptimizerFactory
+from .model.hf_factory import HFModelFactory
 from .registry import register
-from .scheduler import HFSchedulerFactory
-from .scheduler import SchedulerFactory
-from .tokenizer import HFTokenizerFactory
-from .tokenizer import TokenizerFactory
-from .trainer import SFTTrainer
-from .trainer import Trainer
+from .trainer.sft_trainer import SFTTrainer
+from .trainer.trainer import Trainer

--- a/arctic_training/callback/__init__.py
+++ b/arctic_training/callback/__init__.py
@@ -14,4 +14,3 @@
 # limitations under the License.
 
 from .callback import Callback
-from .mixin import CallbackMixin

--- a/arctic_training/checkpoint/__init__.py
+++ b/arctic_training/checkpoint/__init__.py
@@ -13,6 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .ds_engine import DSCheckpointEngine
 from .engine import CheckpointEngine
-from .hf_engine import HFCheckpointEngine

--- a/arctic_training/config/__init__.py
+++ b/arctic_training/config/__init__.py
@@ -14,10 +14,3 @@
 # limitations under the License.
 
 from .base import BaseConfig
-from .checkpoint import CheckpointConfig
-from .data import DataConfig
-from .model import ModelConfig
-from .optimizer import OptimizerConfig
-from .scheduler import SchedulerConfig
-from .tokenizer import TokenizerConfig
-from .trainer import TrainerConfig

--- a/arctic_training/data/__init__.py
+++ b/arctic_training/data/__init__.py
@@ -15,5 +15,4 @@
 
 from . import sft_source
 from .factory import DataFactory
-from .sft_factory import SFTDataFactory
 from .source import DataSource

--- a/arctic_training/model/__init__.py
+++ b/arctic_training/model/__init__.py
@@ -14,5 +14,3 @@
 # limitations under the License.
 
 from .factory import ModelFactory
-from .hf_factory import HFModelFactory
-from .liger_factory import LigerModelFactory

--- a/arctic_training/optimizer/__init__.py
+++ b/arctic_training/optimizer/__init__.py
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .adam_factory import FusedAdamOptimizerFactory
+from . import adam_factory
 from .factory import OptimizerFactory

--- a/arctic_training/scheduler/__init__.py
+++ b/arctic_training/scheduler/__init__.py
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from . import hf_factory
 from .factory import SchedulerFactory
-from .hf_factory import HFSchedulerFactory

--- a/arctic_training/tokenizer/__init__.py
+++ b/arctic_training/tokenizer/__init__.py
@@ -12,6 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .factory import TokenizerFactory
-from .hf_factory import HFTokenizerFactory

--- a/arctic_training/trainer/__init__.py
+++ b/arctic_training/trainer/__init__.py
@@ -13,5 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .sft_trainer import SFTTrainer
 from .trainer import Trainer

--- a/projects/mlp_speculator/train.py
+++ b/projects/mlp_speculator/train.py
@@ -34,10 +34,10 @@ from typing_extensions import Self
 from arctic_training import logger
 from arctic_training import register
 from arctic_training.checkpoint import CheckpointEngine
-from arctic_training.config import ModelConfig
-from arctic_training.config import TrainerConfig
-from arctic_training.model import HFModelFactory
-from arctic_training.trainer import SFTTrainer
+from arctic_training.config.model import ModelConfig
+from arctic_training.config.trainer import TrainerConfig
+from arctic_training.model.hf_factory import HFModelFactory
+from arctic_training.trainer.sft_trainer import SFTTrainer
 from arctic_training.trainer.sft_trainer import to_device
 
 

--- a/projects/swiftkv/train.py
+++ b/projects/swiftkv/train.py
@@ -22,11 +22,11 @@ from deepspeed.runtime.zero import GatheredParameters
 
 from arctic_training import logger
 from arctic_training import register
-from arctic_training.checkpoint import HFCheckpointEngine
-from arctic_training.config import ModelConfig
-from arctic_training.config import TrainerConfig
-from arctic_training.model import HFModelFactory
-from arctic_training.trainer import SFTTrainer
+from arctic_training.checkpoint.hf_engine import HFCheckpointEngine
+from arctic_training.config.model import ModelConfig
+from arctic_training.config.trainer import TrainerConfig
+from arctic_training.model.hf_factory import HFModelFactory
+from arctic_training.trainer.sft_trainer import SFTTrainer
 from arctic_training.trainer.sft_trainer import to_device
 
 


### PR DESCRIPTION
Recent #18 introduces circular import statements. This PR reverts import-lated changes in #18 to solve `ImportError`.
ImportError message: https://app.readthedocs.org/api/v2/build/26864384.txt