### PR TITLE
Fix readthedocs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,9 @@ autodoc_mock_imports = [
     "numpy",
     "devtools",
     "openai",
+    "safetensors",
+    "jsonlines",
+    "tabulate",
 ]
 
 


### PR DESCRIPTION
This PR allows docs to be generated without actually installing the library thus fixes readthedocs build errors.