### PR TITLE
Update meta model names

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install arctic-training
 type: sft
 micro_batch_size: 2
 model:
-  name_or_path: meta-llama/Meta-Llama-3.1-8B-Instruct
+  name_or_path: meta-llama/Llama-3.1-8B-Instruct
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
@@ -89,7 +89,7 @@ training recipe:
 type: my_custom_trainer
 code: path/to/custom_trainers.py
 model:
- name_or_path: meta-llama/Meta-Llama-3.1-8B-Instruct
+ name_or_path: meta-llama/Llama-3.1-8B-Instruct
 data:
  sources:
    - HuggingFaceH4/ultrachat_200k

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -26,7 +26,7 @@ To get started training a model with ArcticTraining, follow the steps below:
       type: sft
       micro_batch_size: 2
       model:
-        name_or_path: meta-llama/Meta-Llama-3.1-8B
+        name_or_path: meta-llama/Llama-3.1-8B-Instruct
       data:
         sources:
           - HuggingFaceH4/ultrachat_200k
@@ -81,7 +81,7 @@ training recipe:
    type: my_custom_trainer
    code: path/to/custom_trainers.py
    model:
-     name_or_path: meta-llama/Meta-Llama-3.1-8B
+     name_or_path: meta-llama/Llama-3.1-8B-Instruct
    data:
      sources:
        - HuggingFaceH4/ultrachat_200k

--- a/projects/mlp_speculator/llama-8b.yaml
+++ b/projects/mlp_speculator/llama-8b.yaml
@@ -7,10 +7,10 @@ gen_train_global_batch_size: 2048
 gen_train_micro_batch_size: 32
 train_iters: 3000
 model:
-  name_or_path: meta-llama/Meta-Llama-3.1-8B-Instruct
+  name_or_path: meta-llama/Llama-3.1-8B-Instruct
   disable_activation_checkpoint: true
 tokenizer:
-  name_or_path: meta-llama/Meta-Llama-3.1-8B-Instruct
+  name_or_path: meta-llama/Llama-3.1-8B-Instruct
 deepspeed:
   zero_optimization:
     stage: 3

--- a/projects/swiftkv/swiftkv-llama-405b.yaml
+++ b/projects/swiftkv/swiftkv-llama-405b.yaml
@@ -5,7 +5,7 @@ gradient_accumulation_steps: 1
 temperature: 2.0
 decoder_loss_mult: 0.0
 model:
-  name_or_path: meta-llama/Meta-Llama-3.1-405B-Instruct
+  name_or_path: meta-llama/Llama-3.1-405B-Instruct
   num_key_value_layers: 63
   key_value_group_size: 1
 deepspeed:

--- a/projects/swiftkv/swiftkv-llama-70b.yaml
+++ b/projects/swiftkv/swiftkv-llama-70b.yaml
@@ -5,7 +5,7 @@ gradient_accumulation_steps: 1
 temperature: 2.0
 decoder_loss_mult: 0.0
 model:
-  name_or_path: meta-llama/Meta-Llama-3.3-70B-Instruct
+  name_or_path: meta-llama/Llama-3.3-70B-Instruct
   num_key_value_layers: 40
   key_value_group_size: 1
 deepspeed:

--- a/projects/swiftkv/swiftkv-llama-8b.yaml
+++ b/projects/swiftkv/swiftkv-llama-8b.yaml
@@ -5,7 +5,7 @@ gradient_accumulation_steps: 1
 temperature: 2.0
 decoder_loss_mult: 0.0
 model:
-  name_or_path: meta-llama/Meta-Llama-3.1-8B-Instruct
+  name_or_path: meta-llama/Llama-3.1-8B-Instruct
   num_key_value_layers: 16
   key_value_group_size: 1
 deepspeed:


### PR DESCRIPTION
The names were recently updated on HuggingFace from `meta-llama/Meta-Llama-*` to `meta-llama/Llama-*`: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct/commit/38ff4e01a70559264c95945aa04b900a11e68422