### PR TITLE
Trigger more meaningful validation error messages when trainer registration failed

### DIFF
--- a/arctic_training/config/trainer.py
+++ b/arctic_training/config/trainer.py
@@ -178,9 +178,7 @@ class TrainerConfig(BaseConfig):
     )
     @classmethod
     def parse_sub_config(
-        cls,
-        v: Any,
-        info: ValidationInfo,
+        cls, v: Any, info: ValidationInfo
     ) -> Union[BaseConfig, List[BaseConfig]]:
         trainer_attr_map = {
             "checkpoint": "checkpoint_engine_type",
@@ -192,7 +190,14 @@ class TrainerConfig(BaseConfig):
         }
         field_name: str = info.field_name  # type: ignore
         trainer_type: str = info.data["type"]
-        trainer_cls = get_registered_trainer(trainer_type)
+        try:
+            trainer_cls = get_registered_trainer(trainer_type)
+        except KeyError as e:
+            raise KeyError(
+                f"Unable to validate {info.field_name=} because trainer type "
+                f"'{trainer_type}' is not registered. Please register the "
+                "trainer and try again."
+            ) from e
         trainer_field_default = getattr(trainer_cls, trainer_attr_map[field_name])[0]
 
         if isinstance(v, tuple) or isinstance(v, list):

--- a/arctic_training/registry/trainer.py
+++ b/arctic_training/registry/trainer.py
@@ -54,16 +54,8 @@ def register_trainer(cls: Type["Trainer"], force: bool = False) -> Type["Trainer
     _validate_class_attribute_set(cls, "config_type")
 
     trainer_attributes = [
-        (
-            "data_factory_type",
-            get_registered_data_factory,
-            register_data_factory,
-        ),
-        (
-            "model_factory_type",
-            get_registered_model_factory,
-            register_model_factory,
-        ),
+        ("data_factory_type", get_registered_data_factory, register_data_factory),
+        ("model_factory_type", get_registered_model_factory, register_model_factory),
         (
             "checkpoint_engine_type",
             get_registered_checkpoint_engine,
@@ -130,6 +122,6 @@ def get_registered_trainer(
         trainer_name = name_or_class.name
 
     if trainer_name not in _supported_trainer_registry:
-        raise ValueError(f"{trainer_name} is not a registered Trainer.")
+        raise KeyError(f"{trainer_name} is not a registered Trainer.")
 
     return _supported_trainer_registry[trainer_name]


### PR DESCRIPTION
If a user fails to register their custom `Trainer` class, or they accidentally supply the incorrect trainer type in the trainer config, validation can proceed in a difficult-to-debug manner. This PR introduces more explicit error messages that trigger in this case and can help the user understand the root cause of the issue faster.