### PR TITLE
Change to sdpa as default attn_implementation

### DIFF
--- a/arctic_training/config/model.py
+++ b/arctic_training/config/model.py
@@ -46,7 +46,7 @@ class ModelConfig(BaseConfig):
     save_name: Optional[str] = None
     """ Name to use when saving the model. """
 
-    attn_implementation: str = "flash_attention_2"
+    attn_implementation: str = "sdpa"
     """ Attention implementation to use. """
 
     disable_activation_checkpoint: bool = False


### PR DESCRIPTION
By default we had flash attention for `attn_implementation`. However, if the user did not have this installed it would result in an error. Adding flash attention as a dependency has its own headaches, so making the default `sdpa` to avoid seeing errors when first trying to library. @sfc-gh-sbekman 