### PR TITLE
Fix trainer double init call

### DIFF
--- a/arctic_training/cli.py
+++ b/arctic_training/cli.py
@@ -49,6 +49,7 @@ def run_script():
     import deepspeed.comm as dist
 
     from arctic_training.config.trainer import get_config
+    from arctic_training.registry.trainer import get_registered_trainer
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -69,7 +70,8 @@ def run_script():
         raise FileNotFoundError(f"Config file {args.config} not found.")
 
     config = get_config(args.config)
-    trainer = config.trainer
+    trainer_cls = get_registered_trainer(config.type)
+    trainer = trainer_cls(config)
     trainer.train()
     if dist.is_initialized():
         dist.barrier()

--- a/arctic_training/config/trainer.py
+++ b/arctic_training/config/trainer.py
@@ -136,10 +136,6 @@ class TrainerConfig(BaseConfig):
         return self
 
     @property
-    def trainer(self):
-        return get_registered_trainer(self.type)(config=self)
-
-    @property
     def checkpoint_engines(self) -> List[partial["CheckpointEngine"]]:
         checkpoint_engines = []
         for checkpoint in self.checkpoint:


### PR DESCRIPTION
A strange interaction was happening when calling the `TrainerConfig.trainer` property, where if the trainer class `__init__` method has an error, the `__init__` will be called twice! Removing trainer init outside of the config class fixes this problem. This property was not very useful anyway and was a vestigial piece of code.

@sfc-gh-sbekman 