### PR TITLE
full deprecate scheduler.lr setting

### DIFF
--- a/arctic_training/config/scheduler.py
+++ b/arctic_training/config/scheduler.py
@@ -14,9 +14,11 @@
 # limitations under the License.
 
 from typing import TYPE_CHECKING
+from typing import Optional
 from typing import Type
 
 from pydantic import Field
+from pydantic import field_validator
 
 from arctic_training.config.base import BaseConfig
 from arctic_training.registry import get_registered_scheduler_factory
@@ -32,8 +34,18 @@ class SchedulerConfig(BaseConfig):
     warmup_ratio: float = Field(default=0.1, ge=0.0, le=1.0)
     """ The fraction of total training steps used for linear learning rate warmup. """
 
-    learning_rate: float = Field(default=5e-4, ge=0.0, alias="lr")
-    """ The initial learning rate. """
+    learning_rate: Optional[float] = Field(default=None, alias="lr")
+    """ The initial learning rate. Deprecated in favor of `optimizer.learning_rate`. """
+
+    @field_validator("learning_rate", mode="after")
+    @classmethod
+    def _deprecated_learning_rate(cls, value: Optional[float]) -> Optional[float]:
+        if value is not None:
+            raise ValueError(
+                "scheduler.learning_rate is deprecated. Use optimizer.learning_rate"
+                " instead."
+            )
+        return value
 
     @property
     def factory(self) -> Type["SchedulerFactory"]:

--- a/arctic_training/config/trainer.py
+++ b/arctic_training/config/trainer.py
@@ -128,12 +128,6 @@ class TrainerConfig(BaseConfig):
         deepspeed.init_distributed()
         return self
 
-    # TODO deprecate scheduler LR and move to optimizer LR
-    @model_validator(mode="after")
-    def copy_lr(self) -> Self:
-        self.optimizer.learning_rate = self.scheduler.learning_rate
-        return self
-
     @property
     def checkpoint_engines(self) -> List[partial["CheckpointEngine"]]:
         checkpoint_engines = []

--- a/projects/mlp_speculator/llama-8b.yaml
+++ b/projects/mlp_speculator/llama-8b.yaml
@@ -36,10 +36,10 @@ logger:
 scheduler:
   name: cosine
   warmup_ratio: 0.05
-  lr: 1e-3
 optimizer:
   betas: [0.9,0.999]
   weight_decay: 0.1
+  lr: 1e-3
 exit_iteration: 11
 checkpoint:
   - type: deepspeed

--- a/projects/swiftkv/swiftkv-llama-405b.yaml
+++ b/projects/swiftkv/swiftkv-llama-405b.yaml
@@ -25,10 +25,10 @@ logger:
   file_output_ranks: [0]
 scheduler:
   warmup_ratio: 0.05
-  lr: 4e-4
 optimizer:
   betas: [0.9,0.999]
   weight_decay: 0.0
+  lr: 4e-4
 checkpoint:
   - type: huggingface
     save_every_n_steps: 10000

--- a/projects/swiftkv/swiftkv-llama-70b.yaml
+++ b/projects/swiftkv/swiftkv-llama-70b.yaml
@@ -25,10 +25,10 @@ logger:
   file_output_ranks: [0]
 scheduler:
   warmup_ratio: 0.05
-  lr: 4e-4
 optimizer:
   betas: [0.9,0.999]
   weight_decay: 0.0
+  lr: 4e-4
 checkpoint:
   - type: huggingface
     save_every_n_steps: 10000

--- a/projects/swiftkv/swiftkv-llama-8b.yaml
+++ b/projects/swiftkv/swiftkv-llama-8b.yaml
@@ -25,10 +25,10 @@ logger:
   file_output_ranks: [0]
 scheduler:
   warmup_ratio: 0.05
-  lr: 0.0002
 optimizer:
   betas: [0.9,0.999]
   weight_decay: 0.0
+  lr: 0.0002
 checkpoint:
   - type: huggingface
     save_every_n_steps: 10000


### PR DESCRIPTION
Since launch we had `optimizer.learning_rate` and `scheduler.learning_rate`. Fully deprecating `scheduler.learning_rate` and adding an error message if a user attempts to set this config field.