### PR TITLE
Use cached environment in actions workflows

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -25,16 +25,12 @@ jobs:
         uses: actions/cache@v4
         with:
           key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-
           path: .venv
       - name: Restore cached pre-commit environment
         uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            pre-commit-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-
       - name: Setup environment
         run: |
           python -m venv .venv

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -17,9 +17,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
+        id: setup_python
         with:
-          python-version: '3.x'
+          python-version: '3.12'
+      - name: Restore cached virtualenv
+        uses: actions/cache@v4
+        with:
+          key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-
+          path: .venv
+      - name: Restore cached pre-commit environment
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            pre-commit-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-
       - name: Install
         run: python scripts/install_deps.py formatting
       - name: Environment print

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -35,8 +35,14 @@ jobs:
           key: pre-commit-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
           restore-keys: |
             pre-commit-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-
-      - name: Install
-        run: python scripts/install_deps.py formatting
+      - name: Setup environment
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          python -m pip install -r requirements.txt
+          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
+          python scripts/install_deps.py formatting
       - name: Environment print
         run: pip list
       - name: Formatting checks

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -39,7 +39,6 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          python -m pip install -r requirements.txt
           echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
           echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
           python scripts/install_deps.py formatting

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -24,8 +24,8 @@ jobs:
       - name: Get latest dependency versions
         id: get_latest_versions
         run: |
-          torch_version=$(python -m pip index versions torch --index-url https://download.pytorch.org/whl/cpu | awk '{print $3}' | sed 's/,//')
-          deepspeed_version=$(python -m pip index versions deepspeed | awk '{print $3}' | sed 's/,//')
+          torch_version=$(python -m pip index versions torch --index-url https://download.pytorch.org/whl/cpu | awk '{print $3}' | sed 's/[,\n]//g')
+          deepspeed_version=$(python -m pip index versions deepspeed | awk '{print $3}' | sed 's/[,\n]//g')
           versions="torch-$torch_version-deepspeed-$deepspeed_version"
           echo "versions=$versions" >> $GITHUB_OUTPUT
       - name: Restore cached virtualenv

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -24,8 +24,8 @@ jobs:
       - name: Get latest dependency versions
         id: get_latest_versions
         run: |
-          torch_version=$(python -m pip index versions torch --index-url https://download.pytorch.org/whl/cpu | awk '{print $3}' | sed 's/[,\n]//g')
-          deepspeed_version=$(python -m pip index versions deepspeed | awk '{print $3}' | sed 's/[,\n]//g')
+          torch_version=$(python -m pip index versions torch --index-url https://download.pytorch.org/whl/cpu | head -n1 | awk '{print $2}' | tr -d '()')
+          deepspeed_version=$(python -m pip index versions deepspeed | head -n1 | awk '{print $2}' | tr -d '()')
           versions="torch-$torch_version-deepspeed-$deepspeed_version"
           echo "versions=$versions" >> $GITHUB_OUTPUT
       - name: Restore cached virtualenv

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -17,12 +17,42 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install
+      - uses: actions/setup-python@v5
+        id: setup_python
+        with:
+          python-version: '3.12'
+      - name: Get latest dependency versions
+        id: get_latest_versions
         run: |
+          torch_version=$(python -m pip index versions torch --index-url https://download.pytorch.org/whl/cpu | awk '{print $3}')
+          deepspeed_version=$(python -m pip index versions deepspeed | awk '{print $3}')
+          versions="torch-$torch_version-deepspeed-$deepspeed_version"
+          echo "versions=$versions" >> $GITHUB_OUTPUT
+      - name: Restore cached virtualenv
+        uses: actions/cache@v4
+        with:
+          key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ steps.get_latest_versions.outputs.versions }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-
+          path: .venv
+      - name: Restore cached torch extensions
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/torch_extensions
+          key: torch-extensions-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ steps.get_latest_versions.outputs.versions }}
+          restore-keys: |
+            torch-extensions-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-
+      - name: Setup environment
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
           python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install ".[testing]"
+          python -m pip install ".[testing]"
       - name: Environment print
-        run: pip list
+        run: |
+          pip list
       - name: Unit Tests
         run: |
           cd tests

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -24,24 +24,20 @@ jobs:
       - name: Get latest dependency versions
         id: get_latest_versions
         run: |
-          torch_version=$(python -m pip index versions torch --index-url https://download.pytorch.org/whl/cpu | awk '{print $3}')
-          deepspeed_version=$(python -m pip index versions deepspeed | awk '{print $3}')
+          torch_version=$(python -m pip index versions torch --index-url https://download.pytorch.org/whl/cpu | awk '{print $3}' | sed 's/,//')
+          deepspeed_version=$(python -m pip index versions deepspeed | awk '{print $3}' | sed 's/,//')
           versions="torch-$torch_version-deepspeed-$deepspeed_version"
           echo "versions=$versions" >> $GITHUB_OUTPUT
       - name: Restore cached virtualenv
         uses: actions/cache@v4
         with:
           key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ steps.get_latest_versions.outputs.versions }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-
           path: .venv
       - name: Restore cached torch extensions
         uses: actions/cache@v4
         with:
           path: ~/.cache/torch_extensions
           key: torch-extensions-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ steps.get_latest_versions.outputs.versions }}
-          restore-keys: |
-            torch-extensions-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-
       - name: Setup environment
         run: |
           python -m venv .venv

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -24,8 +24,8 @@ jobs:
       - name: Get latest dependency versions
         id: get_latest_versions
         run: |
-          torch_version=$(python -m pip index versions torch --index-url https://download.pytorch.org/whl/cpu | head -n1 | awk '{print $2}' | tr -d '()')
-          deepspeed_version=$(python -m pip index versions deepspeed | head -n1 | awk '{print $2}' | tr -d '()')
+          torch_version=$(python -m pip index versions torch --index-url https://download.pytorch.org/whl/cpu | perl -ne 'm|Available versions: ([\d\.]+)| && print $1')
+          deepspeed_version=$(python -m pip index versions deepspeed | perl -ne 'm|Available versions: ([\d\.]+)| && print $1')
           versions="torch-$torch_version-deepspeed-$deepspeed_version"
           echo "versions=$versions" >> $GITHUB_OUTPUT
       - name: Restore cached virtualenv


### PR DESCRIPTION
Setting up the python environment & dependency install for formatting and unit test workflows took a considerable amount of time (> 50% of total workflow time). Caching the environments speeds up unit test feedback for better development!

```
Formatting:   40s --> 20s
Unit-tests: 2m30s --> 58s
```

Cached environments can be seen under the repo "Actions" tab --> "Management" --> "Caches". If necessary, we can remove cached environments to force a new environment build.

For unit tests, we check the latest torch and deepspeed version and trigger a new environment build if they are updated from the cached versions.