### PR TITLE
Fix error with unit test env caching

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -51,5 +51,6 @@ jobs:
           pip list
       - name: Unit Tests
         run: |
+          python -m pip install ".[testing]"
           cd tests
           python -m pytest . -m "not gpu" -s -v

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -51,6 +51,5 @@ jobs:
           pip list
       - name: Unit Tests
         run: |
-          python -m pip install ".[testing]"
           cd tests
           python -m pytest . -m "not gpu" -s -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,11 +14,18 @@
 # limitations under the License.
 
 import os
+import sys
+from pathlib import Path
 
 import pytest
 
 
 def pytest_configure(config):
+    # allow having multiple repository checkouts and not needing to remember to rerun
+    # 'pip install .' when switching between checkouts and running tests.
+    git_repo_path = str(Path(__file__).resolve().parents[1])
+    sys.path.insert(0, git_repo_path)
+
     # TODO: Make it so that cpu and gpu tests can be run with a single command.
     # This requires some work with tearing down/setting up dist environments
     # that have not been worked out yet.


### PR DESCRIPTION
We need to ensure we are still installing the latest checked out version of ArcticTraining even when using a cached environment.