### PR TITLE
Add ZeRO3 checkpoint support for PEFT models

### DIFF
--- a/arctic_training/checkpoint/hf_engine.py
+++ b/arctic_training/checkpoint/hf_engine.py
@@ -98,9 +98,6 @@ class HFCheckpointEngine(CheckpointEngine):
         for k, v in model_to_save.named_parameters():
             v_p = self._get_param(v)
             if model.global_rank == 0:
-                if not v.requires_grad:
-                    continue
-                print("SAVING", k, v_p.numel())
                 output_state_dict[k] = v_p
 
                 so_far_params += v_p.numel()


### PR DESCRIPTION
Quick test to compare outputs with zero2 / zero3:
```yaml
type: sft
code: ./tests/helpers.py
micro_batch_size: 1
deepspeed:
  zero_optimization:
    stage: 2
model:
  name_or_path: Felladrin/Llama-160M-Chat-v1
  peft_config:
    peft_type: Lora
    lora_alpha: 0.125
    lora_dropout: 0.1
    r: 8
    bias: none
    task_type: CAUSAL_LM
    target_modules:
      - q_proj
      - k_proj
      - v_proj
      - o_proj
      - down_proj
      - up_proj
      - gate_proj
data:
  sources:
    - HuggingFaceH4/ultrachat_200k-truncated
  use_data_cache: false
  max_length: 2048
checkpoint:
  type: huggingface
  output_dir: ./llama-zero2-lora
  save_end_of_training: true
```
```yaml
type: sft
code: ./tests/helpers.py
micro_batch_size: 1
deepspeed:
  zero_optimization:
    stage: 3
model:
  name_or_path: Felladrin/Llama-160M-Chat-v1
  peft_config:
    peft_type: Lora
    lora_alpha: 0.125
    lora_dropout: 0.1
    r: 8
    bias: none
    task_type: CAUSAL_LM
    target_modules:
      - q_proj
      - k_proj
      - v_proj
      - o_proj
      - down_proj
      - up_proj
      - gate_proj
data:
  sources:
    - HuggingFaceH4/ultrachat_200k-truncated
  use_data_cache: false
  max_length: 2048
checkpoint:
  type: huggingface
  output_dir: ./llama-zero3-lora
  save_end_of_training: true
```
If we compare the output checkpoint sizes, we see they match:
```shell
❯ du -sh llama-zero2-lora/
3.9M    llama-zero2-lora/
❯ du -sh llama-zero3-lora/
3.9M    llama-zero3-lora/
```

TODO:
- [x] Validate models loaded from each checkpoint match
- [ ] ~~Add unit test(s)~~
- [ ] ~~Clean up implementation~~