### PR TITLE
Fix cache path collision

### DIFF
--- a/arctic_training/config/data.py
+++ b/arctic_training/config/data.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 from typing import Type
 from typing import Union
@@ -75,8 +76,8 @@ class DataConfig(BaseConfig):
     use_data_cache: bool = True
     """ Whether to cache loaded data. """
 
-    cache_processed_data: bool = False
-    """ Whether to cache processed data. """
+    cache_processed_data: Optional[bool] = None
+    """ Deprecated, please use "use_data_cache". """
 
     cache_dir: Path = Path("/tmp/")
     """ Directory to store cached data. """
@@ -84,6 +85,16 @@ class DataConfig(BaseConfig):
     @property
     def factory(self) -> Type["DataFactory"]:
         return get_registered_data_factory(self.type)
+
+    @field_validator("cache_processed_data", mode="after")
+    @classmethod
+    def deprecate_cache_processed_data(cls, v: Optional[bool]) -> Optional[bool]:
+        if v is not None:
+            logger.warning(
+                "The 'cache_processed_data' field is deprecated. Please use"
+                " 'use_data_cache' instead."
+            )
+        return v
 
     @field_validator("sources", "eval_sources", mode="before")
     def create_source_config_from_name(

--- a/arctic_training/data/factory.py
+++ b/arctic_training/data/factory.py
@@ -24,6 +24,7 @@ from datasets import concatenate_datasets
 from torch.utils.data import DataLoader
 from torch.utils.data import RandomSampler
 from transformers import PreTrainedTokenizerBase
+from datasets import load_from_disk
 
 from arctic_training.callback.mixin import CallbackMixin
 from arctic_training.callback.mixin import callback_wrapper
@@ -73,11 +74,18 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
 
     def __call__(self) -> Tuple[DataLoader, Optional[DataLoader]]:
         def get_data_split(split: str) -> Optional[DatasetType]:
+            cache_path = self.cache_path(split)
+            if self.config.use_data_cache and cache_path.exists():
+                return load_from_disk(cache_path.as_posix())
+
             data_sources = self._get_data_sources(split=split)
             if len(data_sources) == 0:
                 return None
             dataset = self.load(data_sources, split=split)
             dataset = self._truncate_data(dataset)
+
+            if self.config.use_data_cache:
+                dataset.save_to_disk(cache_path.as_posix())
             return dataset
 
         training_data = get_data_split("train")

--- a/arctic_training/data/factory.py
+++ b/arctic_training/data/factory.py
@@ -14,16 +14,13 @@
 # limitations under the License.
 
 from abc import ABC
-from pathlib import Path
 from typing import TYPE_CHECKING
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Tuple
 
 import torch
 from datasets import concatenate_datasets
-from datasets import load_from_disk
 from torch.utils.data import DataLoader
 from torch.utils.data import RandomSampler
 from transformers import PreTrainedTokenizerBase
@@ -32,8 +29,6 @@ from arctic_training.callback.mixin import CallbackMixin
 from arctic_training.callback.mixin import callback_wrapper
 from arctic_training.config.data import DataConfig
 from arctic_training.data.utils import DatasetType
-from arctic_training.data.utils import calculate_hash_from_args
-from arctic_training.logging import logger
 from arctic_training.registry import RegistryMeta
 from arctic_training.registry import _validate_class_attribute_set
 from arctic_training.registry import _validate_class_attribute_type
@@ -81,17 +76,8 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
             data_sources = self._get_data_sources(split=split)
             if len(data_sources) == 0:
                 return None
-
-            cache_path = self._get_processed_data_cache_path(data_sources)
-            if self.config.use_data_cache and cache_path.exists():
-                logger.info(f"Loading from cache path {cache_path.as_posix()}")
-                return load_from_disk(cache_path.as_posix())
-
             dataset = self.load(data_sources, split=split)
             dataset = self._truncate_data(dataset)
-            if self.config.use_data_cache:
-                dataset.save_to_disk(cache_path.as_posix())
-
             return dataset
 
         training_data = get_data_split("train")
@@ -134,28 +120,6 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
         """The total number of processes in the world."""
         return self.config.world_size
 
-    @property
-    def cache_path_args(self) -> Dict:
-        cache_path_args = self.config.model_dump()
-        del cache_path_args["sources"]
-        del cache_path_args["eval_sources"]
-        return cache_path_args
-
-    def _get_source_cache_path(self, source: "DataSource") -> Path:
-        hash_str = calculate_hash_from_args(
-            self.cache_path_args, source.cache_path_args
-        )
-        return self.config.cache_dir / hash_str
-
-    def _get_processed_data_cache_path(
-        self, data_source_list: List["DataSource"]
-    ) -> Path:
-        hash_str = calculate_hash_from_args(
-            self.cache_path_args,
-            *[source.cache_path_args for source in data_source_list],
-        )
-        return self.config.cache_dir / hash_str
-
     def _get_data_sources(self, split: str) -> List["DataSource"]:
         if split == "train":
             data_source_configs = self.config.sources
@@ -193,11 +157,7 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
         """Loads data from one or more data sources and concatenates into a single dataset."""
         datasets = []
         for data_source in data_sources:
-            if self.config.use_data_cache:
-                cache_path = self._get_source_cache_path(data_source)
-            else:
-                cache_path = None
-            dataset = data_source(split, cache_path=cache_path)
+            dataset = data_source(split)
             datasets.append(dataset)
         dataset = concatenate_datasets(datasets)
         return dataset

--- a/arctic_training/data/source.py
+++ b/arctic_training/data/source.py
@@ -62,6 +62,7 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
         disable_caching()
         cache_path = self.cache_path(split)
         if self.data_factory.config.use_data_cache and cache_path.exists():
+            print("LOADING CACHE", cache_path)
             logger.info(f"Loading from cache path {cache_path.as_posix()}")
             return load_from_disk(cache_path.as_posix())
 
@@ -88,6 +89,7 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
                 )
 
         if self.data_factory.config.use_data_cache:
+            print("SAVING CACHE", cache_path)
             dataset.save_to_disk(cache_path.as_posix())
 
         return dataset

--- a/arctic_training/data/source.py
+++ b/arctic_training/data/source.py
@@ -62,7 +62,6 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
         disable_caching()
         cache_path = self.cache_path(split)
         if self.data_factory.config.use_data_cache and cache_path.exists():
-            print("LOADING CACHE", cache_path)
             logger.info(f"Loading from cache path {cache_path.as_posix()}")
             return load_from_disk(cache_path.as_posix())
 
@@ -89,7 +88,6 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
                 )
 
         if self.data_factory.config.use_data_cache:
-            print("SAVING CACHE", cache_path)
             dataset.save_to_disk(cache_path.as_posix())
 
         return dataset

--- a/arctic_training/data/source.py
+++ b/arctic_training/data/source.py
@@ -17,7 +17,6 @@ from abc import ABC
 from abc import abstractmethod
 from pathlib import Path
 from typing import Dict
-from typing import Optional
 
 from datasets import disable_caching
 from datasets import load_from_disk
@@ -27,6 +26,7 @@ from arctic_training.callback.mixin import callback_wrapper
 from arctic_training.config.data import DataSourceConfig
 from arctic_training.data.factory import DataFactory
 from arctic_training.data.utils import DatasetType
+from arctic_training.data.utils import calculate_hash_from_args
 from arctic_training.logging import logger
 from arctic_training.registry import RegistryMeta
 from arctic_training.registry import _validate_class_attribute_set
@@ -57,9 +57,10 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
         self._data_factory = data_factory
         self.config = config
 
-    def __call__(self, split: str, cache_path: Optional[Path] = None) -> DatasetType:
+    def __call__(self, split: str) -> DatasetType:
         disable_caching()
-        if cache_path is not None and cache_path.exists():
+        cache_path = self.cache_path(split)
+        if self.data_factory.config.use_data_cache and cache_path.exists():
             logger.info(f"Loading from cache path {cache_path.as_posix()}")
             return load_from_disk(cache_path.as_posix())
 
@@ -85,7 +86,7 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
                     f" {self.name} with config {self.config} for split {split}"
                 )
 
-        if cache_path is not None:
+        if self.data_factory.config.use_data_cache:
             dataset.save_to_disk(cache_path.as_posix())
 
         return dataset
@@ -108,11 +109,37 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
 
     @property
     def cache_path_args(self) -> Dict:
-        cache_path_args = self.config.model_dump()
-        cache_path_args["_tokenizer_path_or_name"] = (
-            self.trainer.config.tokenizer.name_or_path
-        )
-        return self.config.model_dump()
+        """Returns a dictionary of config fields that affect the cache path calculation."""
+
+        # Some fields in the DataConfig should not affect cache path:
+        # - sources / eval_sources: these are captures in the data source cache args
+        # - cache_dir: this is the root of the cache path
+        # - num_proc: does not affect output data
+        # - train_eval_split: this is used after data is loaded/cached
+        # - use_data_cache: does not affect the output data
+        exclude_fields = [
+            "sources",
+            "eval_sources",
+            "cache_dir",
+            "num_proc",
+            "train_eval_split",
+            "use_data_cache",
+        ]
+        cache_path_args = {
+            "data_factory_args": {
+                k: v
+                for k, v in self.data_factory.config.model_dump().items()
+                if k not in exclude_fields
+            },
+            "data_source_args": self.config.model_dump(),
+            "tokenizer_factory_args": self.trainer.config.tokenizer.model_dump(),
+        }
+        return cache_path_args
+
+    def cache_path(self, split: str) -> Path:
+        """Returns the cache path for the data source split."""
+        hash_str = calculate_hash_from_args(split, **self.cache_path_args)
+        return self.data_factory.config.cache_dir / hash_str
 
     @callback_wrapper("load")
     @abstractmethod

--- a/tests/checkpoint/__init__.py
+++ b/tests/checkpoint/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/checkpoint/test_ds_engine.py
+++ b/tests/checkpoint/test_ds_engine.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from utils import models_are_equal
-
 from arctic_training.config.trainer import get_config
 from arctic_training.registry import get_registered_trainer
+
+from .utils import models_are_equal
 
 
 def test_ds_engine(tmp_path, model_name):

--- a/tests/checkpoint/test_hf_engine.py
+++ b/tests/checkpoint/test_hf_engine.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from utils import models_are_equal
-
 from arctic_training.config.trainer import get_config
 from arctic_training.registry import get_registered_trainer
+
+from .utils import models_are_equal
 
 
 def test_hf_engine(tmp_path, model_name):

--- a/tests/data/__init__.py
+++ b/tests/data/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/data/test_sft_factory.py
+++ b/tests/data/test_sft_factory.py
@@ -18,25 +18,29 @@ from types import SimpleNamespace
 import pytest
 from transformers import AutoTokenizer
 
+from arctic_training.config.tokenizer import TokenizerConfig
 from arctic_training.data.sft_factory import SFTDataConfig
 
 
 @pytest.fixture(scope="function")
 def sft_data_factory(training_sources):
-    config_dict = {
-        "type": "sft",
-        "sources": training_sources,
-    }
-    data_config = SFTDataConfig(**config_dict)
+    model_name = "HuggingFaceTB/SmolLM-135M-Instruct"
+    data_config = SFTDataConfig(
+        type="sft",
+        sources=training_sources,
+    )
+    tokenizer_config = TokenizerConfig(
+        type="huggingface",
+        name_or_path=model_name,
+    )
 
     # We just need an object that specifies the tokenizer and micro batch size
     # for SFT data loading. We don't need to actually run the trainer.
-    model_name = "HuggingFaceTB/SmolLM-135M-Instruct"
     dummy_trainer = SimpleNamespace(
         config=SimpleNamespace(
             micro_batch_size=1,
             data=data_config,
-            tokenizer=SimpleNamespace(name_or_path=model_name),
+            tokenizer=tokenizer_config,
         ),
         tokenizer=AutoTokenizer.from_pretrained(model_name),
     )

--- a/tests/data/test_sft_factory.py
+++ b/tests/data/test_sft_factory.py
@@ -13,54 +13,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from types import SimpleNamespace
+from pathlib import Path
 from typing import List
 
 import pytest
-from transformers import AutoTokenizer
 
-from arctic_training.config.tokenizer import TokenizerConfig
-from arctic_training.data.sft_factory import SFTDataConfig
-from arctic_training.data.sft_factory import SFTDataFactory
-
-
-@pytest.fixture(scope="function")
-def sft_data_factory(model_name:str, training_sources:List[str]) -> SFTDataFactory:
-    model_name = "HuggingFaceTB/SmolLM-135M-Instruct"
-    data_config = SFTDataConfig(
-        type="sft",
-        sources=training_sources,
-    )
-    tokenizer_config = TokenizerConfig(
-        type="huggingface",
-        name_or_path=model_name,
-    )
-
-    # We just need an object that specifies the tokenizer and micro batch size
-    # for SFT data loading. We don't need to actually run the trainer.
-    dummy_trainer = SimpleNamespace(
-        config=SimpleNamespace(
-            micro_batch_size=1,
-            data=data_config,
-            tokenizer=tokenizer_config,
-        ),
-        tokenizer=AutoTokenizer.from_pretrained(model_name),
-    )
-
-    return data_config.factory(dummy_trainer)
+from .utils import create_sft_data_factory
 
 
 @pytest.mark.parametrize(
     "training_sources, expected_sum",
     [
-        (["HuggingFaceH4/ultrachat_200k-truncated"], 225529637),
+        (["HuggingFaceH4/ultrachat_200k-truncated"], 487103798),
         (
             ["HuggingFaceH4/ultrachat_200k-truncated", "Open-Orca/SlimOrca-truncated"],
-            355730323,
+            591408621,
         ),
     ],
 )
-def test_generated_data(sft_data_factory: SFTDataFactory, expected_sum: int):
+def test_generated_data(
+    model_name: str, training_sources: List[str], expected_sum: int, tmp_path: Path
+):
+    sft_data_factory = create_sft_data_factory(
+        model_name=model_name, sources=training_sources, cache_dir=tmp_path
+    )
     training_dataloader, _ = sft_data_factory()
 
     # Quick check that the data is the same as expected. The sum value was
@@ -73,3 +49,27 @@ def test_generated_data(sft_data_factory: SFTDataFactory, expected_sum: int):
     assert (
         tensor_sum == expected_sum
     ), f"Incorrect tensor sum: {tensor_sum}. Expected {expected_sum}"
+
+
+def test_sft_factory_cache_path_uniqueness(model_name: str, tmp_path: Path):
+    data_sources = [
+        "HuggingFaceH4/ultrachat_200k-truncated",
+        "Open-Orca/SlimOrca-truncated",
+    ]
+    data_factory_1 = create_sft_data_factory(
+        model_name=model_name, sources=data_sources, cache_dir=tmp_path
+    )
+
+    data_sources = data_sources[:1]
+    data_factory_2 = create_sft_data_factory(
+        model_name=model_name, sources=data_sources, cache_dir=tmp_path
+    )
+
+    cache_path_1 = data_factory_1.cache_path(
+        data_factory_1._get_data_sources(split="train"), "train"
+    )
+    cache_path_2 = data_factory_2.cache_path(
+        data_factory_2._get_data_sources(split="train"), "train"
+    )
+
+    assert cache_path_1 != cache_path_2, "Cache paths were not unique"

--- a/tests/data/test_sft_factory.py
+++ b/tests/data/test_sft_factory.py
@@ -14,16 +14,18 @@
 # limitations under the License.
 
 from types import SimpleNamespace
+from typing import List
 
 import pytest
 from transformers import AutoTokenizer
 
 from arctic_training.config.tokenizer import TokenizerConfig
 from arctic_training.data.sft_factory import SFTDataConfig
+from arctic_training.data.sft_factory import SFTDataFactory
 
 
 @pytest.fixture(scope="function")
-def sft_data_factory(training_sources):
+def sft_data_factory(model_name:str, training_sources:List[str]) -> SFTDataFactory:
     model_name = "HuggingFaceTB/SmolLM-135M-Instruct"
     data_config = SFTDataConfig(
         type="sft",
@@ -58,7 +60,7 @@ def sft_data_factory(training_sources):
         ),
     ],
 )
-def test_generated_data(sft_data_factory, expected_sum):
+def test_generated_data(sft_data_factory: SFTDataFactory, expected_sum: int):
     training_dataloader, _ = sft_data_factory()
 
     # Quick check that the data is the same as expected. The sum value was

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -14,34 +14,22 @@
 # limitations under the License.
 
 from pathlib import Path
-from types import SimpleNamespace
 
-from arctic_training.config.tokenizer import TokenizerConfig
-from arctic_training.data.sft_factory import SFTDataConfig
+from .utils import create_sft_data_factory
 
 
-def test_cache_path_uniqueness(model_name: str, tmp_path: Path):
+def test_data_source_cache_path_uniqueness(model_name: str, tmp_path: Path):
     data_sources = [
         "HuggingFaceH4/ultrachat_200k",
         "Open-Orca/SlimOrca",
     ]
-    data_config = SFTDataConfig(
-        type="sft",
+    data_factory = create_sft_data_factory(
+        model_name=model_name,
         sources=data_sources,
         eval_sources=data_sources,
-        use_data_cache=True,
         cache_dir=tmp_path,
     )
-    tokenizer_config = TokenizerConfig(type="huggingface", name_or_path=model_name)
 
-    dummy_trainer = SimpleNamespace(
-        config=SimpleNamespace(
-            data=data_config,
-            tokenizer=tokenizer_config,
-        ),
-    )
-
-    data_factory = data_config.factory(trainer=dummy_trainer)
     cache_paths = [
         s.cache_path("train") for s in data_factory._get_data_sources("train")
     ] + [s.cache_path("eval") for s in data_factory._get_data_sources("eval")]

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -24,9 +24,6 @@ def test_cache_path_uniqueness(model_name: str, tmp_path: Path):
     data_sources = [
         "HuggingFaceH4/ultrachat_200k",
         "Open-Orca/SlimOrca",
-        "meta-math/MetaMathQA",
-        "ise-uiuc/Magicoder-OSS-Instruct-75K",
-        "lmsys/lmsys-chat-1m",
     ]
     data_config = SFTDataConfig(
         type="sft",

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -42,9 +42,9 @@ def test_cache_path_uniqueness(model_name: str, tmp_path: Path):
     )
 
     data_factory = data_config.factory(trainer=dummy_trainer)
-    cache_paths = [s.cache_path for s in data_factory._get_data_sources("train")] + [
-        s.cache_path for s in data_factory._get_data_sources("eval")
-    ]
+    cache_paths = [
+        s.cache_path("train") for s in data_factory._get_data_sources("train")
+    ] + [s.cache_path("eval") for s in data_factory._get_data_sources("eval")]
     assert len(cache_paths) == 2 * len(
         data_sources
     ), "Cache paths were not generated for all data sources"

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from arctic_training.config.tokenizer import TokenizerConfig
+from arctic_training.data.sft_factory import SFTDataConfig
+
+
+def test_cache_path_uniqueness(model_name: str, tmp_path: Path):
+    data_sources = [
+        "HuggingFaceH4/ultrachat_200k",
+        "Open-Orca/SlimOrca",
+        "meta-math/MetaMathQA",
+        "ise-uiuc/Magicoder-OSS-Instruct-75K",
+        "lmsys/lmsys-chat-1m",
+    ]
+    data_config = SFTDataConfig(
+        type="sft",
+        sources=data_sources,
+        eval_sources=data_sources,
+        use_data_cache=True,
+        cache_dir=tmp_path,
+    )
+    tokenizer_config = TokenizerConfig(type="huggingface", name_or_path=model_name)
+
+    dummy_trainer = SimpleNamespace(
+        config=SimpleNamespace(
+            data=data_config,
+            tokenizer=tokenizer_config,
+        ),
+    )
+
+    data_factory = data_config.factory(trainer=dummy_trainer)
+    cache_paths = [s.cache_path for s in data_factory._get_data_sources("train")] + [
+        s.cache_path for s in data_factory._get_data_sources("eval")
+    ]
+    assert len(cache_paths) == 2 * len(
+        data_sources
+    ), "Cache paths were not generated for all data sources"
+    assert len(cache_paths) == len(set(cache_paths)), "Cache paths were not unique"

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -1,0 +1,45 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+from pathlib import Path
+from arctic_training.data.sft_factory import SFTDataFactory
+from arctic_training.data.sft_factory import SFTDataConfig
+from arctic_training.config.tokenizer import TokenizerConfig
+from typing import Optional
+from types import SimpleNamespace
+from transformers import AutoTokenizer
+
+def create_sft_data_factory(model_name: str, sources: List[str], eval_sources: List[str] = [], cache_dir: Optional[Path] = None) -> SFTDataFactory:
+    data_config = SFTDataConfig(
+        type="sft",
+        sources=sources,
+        eval_sources=eval_sources,
+        use_data_cache=cache_dir is not None,
+        cache_dir=cache_dir,
+    )
+    tokenizer_config = TokenizerConfig(type="huggingface", name_or_path=model_name)
+
+    dummy_trainer = SimpleNamespace(
+        config=SimpleNamespace(
+            micro_batch_size=1,
+            data=data_config,
+            tokenizer=tokenizer_config,
+        ),
+        tokenizer=AutoTokenizer.from_pretrained(model_name),
+    )
+
+    data_factory = data_config.factory(trainer=dummy_trainer)
+    return data_factory

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -13,16 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 from pathlib import Path
-from arctic_training.data.sft_factory import SFTDataFactory
-from arctic_training.data.sft_factory import SFTDataConfig
-from arctic_training.config.tokenizer import TokenizerConfig
-from typing import Optional
 from types import SimpleNamespace
+from typing import List
+from typing import Optional
+
 from transformers import AutoTokenizer
 
-def create_sft_data_factory(model_name: str, sources: List[str], eval_sources: List[str] = [], cache_dir: Optional[Path] = None) -> SFTDataFactory:
+from arctic_training.config.tokenizer import TokenizerConfig
+from arctic_training.data.sft_factory import SFTDataConfig
+from arctic_training.data.sft_factory import SFTDataFactory
+
+
+def create_sft_data_factory(
+    model_name: str,
+    sources: List[str],
+    eval_sources: List[str] = [],
+    cache_dir: Optional[Path] = None,
+) -> SFTDataFactory:
     data_config = SFTDataConfig(
         type="sft",
         sources=sources,


### PR DESCRIPTION
This PR addresses two issues:
1. In some cases we were calculating the cache path incorrectly and over-writing an existing cache
2. Some of the field values used to calculate the hash path were not necessary

Additionally, cleaning up the cache path code to be easier to read and understand