### PR TITLE
add Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,12 @@ formatting manually using:
 pre-commit run --all-files
 ```
 
+It's better to use:
+```
+make format
+````
+as it'll install all the required venv things automatically for you and will do the right thing.
+
 If a formatting test fails, some pre-commit hooks will attempt to modify the
 code in place. Other formatting checks, like the [mypy type
 checker](https://mypy-lang.org/) will require you to make modifications to the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,14 +44,30 @@ previous `git commit` command.
 A collection of unit tests can be found in the `tests/` directory. Broadly,
 there are two types of tests: CPU-based and GPU-based.
 
-To run the CPU-based tests:
+To run all tests:
 ```bash
-cd tests
-python -m pytest -m cpu
+make test
+```
+or:
+```bash
+pytest tests
 ```
 
-To run the GPU-based tests:
+To run only the CPU-based tests:
 ```bash
-cd tests
-python -m pytest -m gpu
+make test-cpu
+```
+or:
+```bash
+pytest -m "not gpu" tests
+```
+
+To run only the GPU-based tests:
+
+```bash
+make test-gpu
+```
+or:
+```bash
+pytest -m gpu tests
 ```

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,14 @@ help: ## this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 	echo $(MAKEFILE_LIST)
 
-test: ## run tests
+test: ## run cpu and gpu tests
 	pytest --disable-warnings --instafail ./tests/
+
+test-cpu: ## run cpu-only tests
+	pytest --disable-warnings --instafail -m "not gpu" ./tests/
+
+test-gpu: ## run gpu-only tests
+	pytest --disable-warnings --instafail -m gpu ./tests/
 
 format: ## fix formatting
 	@if [ ! -d "venv" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # usage: make help
 
-.PHONY: help format test
+.PHONY: help test test-cpu test-gpu format
 .DEFAULT_GOAL := help
 
 help: ## this help

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# usage: make help
+
+.PHONY: help format test
+.DEFAULT_GOAL := help
+
+help: ## this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[0-9a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	echo $(MAKEFILE_LIST)
+
+test: ## run tests
+	pytest --disable-warnings --instafail ./tests/
+
+format: ## fix formatting
+	@if [ ! -d "venv" ]; then \
+		pip install virtualenv; \
+		virtualenv venv; \
+		. venv/bin/activate; \
+		pip install pre-commit; \
+		pre-commit clean; \
+		pre-commit uninstall; \
+		pre-commit install; \
+	fi
+	. venv/bin/activate && pre-commit run --all-files && deactivate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
 
 testing = [
     "pytest",
+    "pytest-instafail",
 ]
 
 formatting = [


### PR DESCRIPTION
1. Start encapsulating complex workflow things into simple `Makefile` targets that can run out of the box.

Added:

- `make format`
- `make test`
- `make test-cpu`
- `make test-gpu`

This `Makefile` sports also an automatic `make help` ;)

```
$ make help

Usage:
  make <target>
  help                    this help
  test                    run cpu and gpu tests
  test-cpu                run cpu-only tests
  test-gpu                run gpu-only tests
  format                  fix formatting
```

2. fix the outdated doc
3. add testing dependencies that make tests running experience better
