### PR TITLE
Support WSD learning rate schedule

### DIFF
--- a/arctic_training/config/scheduler.py
+++ b/arctic_training/config/scheduler.py
@@ -31,9 +31,6 @@ class SchedulerConfig(BaseConfig):
     type: str = ""
     """ Scheduler factory type. Defaults to the `scheduler_factory_type` of the trainer. """
 
-    warmup_ratio: float = Field(default=0.1, ge=0.0, le=1.0)
-    """ The fraction of total training steps used for linear learning rate warmup. """
-
     learning_rate: Optional[float] = Field(default=None, alias="lr")
     """ The initial learning rate. Deprecated in favor of `optimizer.learning_rate`. """
 

--- a/arctic_training/scheduler/wsd_factory.py
+++ b/arctic_training/scheduler/wsd_factory.py
@@ -1,0 +1,53 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+from typing import Literal
+
+from torch.optim.lr_scheduler import LambdaLR
+from transformers import get_wsd_schedule
+
+from arctic_training.config.scheduler import SchedulerConfig
+from arctic_training.scheduler.factory import SchedulerFactory
+
+
+class WSDSchedulerConfig(SchedulerConfig):
+    """See: https://huggingface.co/docs/transformers/en/main_classes/optimizer_schedules#transformers.get_wsd_schedule"""
+
+    name: str = "wsd"
+    num_warmup_steps: int
+    num_decay_steps: int
+    warmup_type: Literal["linear", "cosine", "1-sqrt"] = "linear"
+    decay_type: Literal["linear", "cosine", "1-sqrt"] = "linear"
+    min_lr_ratio: float = 0.0
+    num_cycles: float = 0.5
+
+
+class WSDSchedulerFactory(SchedulerFactory):
+    name = "wds"
+    config: WSDSchedulerConfig
+
+    def create_scheduler(self, optimizer: Any) -> LambdaLR:
+        return get_wsd_schedule(
+            name=self.config.name,
+            optimizer=optimizer,
+            num_warmup_steps=self.config.num_warmup_steps,
+            num_decay_steps=self.config.num_decay_steps,
+            warmup_type=self.config.warmup_type,
+            decay_type=self.config.decay_type,
+            min_lr_ratio=self.config.min_lr_ratio,
+            num_cycles=self.config.num_cycles,
+            num_training_steps=self.trainer.training_horizon,
+        )

--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -235,11 +235,6 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
             // self.config.gradient_accumulation_steps
         )
 
-    @property
-    def warmup_steps(self) -> int:
-        """Number of warmup steps."""
-        return int(self.config.scheduler.warmup_ratio * self.training_horizon)
-
     @callback_wrapper("loss")
     @abstractmethod
     def loss(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:


### PR DESCRIPTION
Warmup-stable-decay (WSD) is a common learning rate schedule which is parameterized slightly differently than the default linear decay schedule (canonically by step count rather than fraction of training steps, at least in `transformers`). This PR adds support for WSD to the scheduler factory, moving the warmup ratio out of the base scheduler config and into the `HFSchedulerConfig` class.

It may also make sense to rename `HFScheduler*` configs and classes because in truth the config and factory are specific to linear schedules and do not have the right parameters to support other schedules like WSD.