### PR TITLE
remove redundant code

### DIFF
--- a/arctic_training/data/factory.py
+++ b/arctic_training/data/factory.py
@@ -156,7 +156,7 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
             data_length = torch.zeros(self.world_size).to(self.trainer.device)
             data_length[self.global_rank] = local_length
             torch.distributed.all_reduce(data_length, op=torch.distributed.ReduceOp.SUM)
-            shortest_length = int(data_length.min().cpu().item())
+            shortest_length = int(data_length.min().item())
             del data_length  # clean the memory
         else:
             shortest_length = local_length


### PR DESCRIPTION
`.cpu().item()` and `.item()` do the same thing as at the end a pure python number is returned by `item()`