### PR TITLE
Error on yaml config duplicate keys

### DIFF
--- a/arctic_training/config/trainer.py
+++ b/arctic_training/config/trainer.py
@@ -43,6 +43,7 @@ from arctic_training.config.model import ModelConfig
 from arctic_training.config.optimizer import OptimizerConfig
 from arctic_training.config.scheduler import SchedulerConfig
 from arctic_training.config.tokenizer import TokenizerConfig
+from arctic_training.config.utils import UniqueKeyLoader
 from arctic_training.config.wandb import WandBConfig
 from arctic_training.registry import _get_class_attr_type_hints
 from arctic_training.registry import get_registered_checkpoint_engine
@@ -351,7 +352,7 @@ def get_config(config_file_or_dict: Union[Path, Dict]) -> BaseConfig:
         config_dir = Path.cwd()
     else:
         with open(config_file_or_dict, "r") as f:
-            config_dict = yaml.safe_load(f)
+            config_dict = yaml.load(f, Loader=UniqueKeyLoader)
         config_dir = config_file_or_dict.parent
 
     trainer_type = config_dict.get("type", TRAINER_DEFAULT)

--- a/arctic_training/config/utils.py
+++ b/arctic_training/config/utils.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 import yaml
 
 
@@ -28,11 +26,3 @@ class UniqueKeyLoader(yaml.SafeLoader):
                 raise ValueError(f"Duplicate {key!r} key found in YAML.")
             mapping.add(key)
         return super().construct_mapping(node, deep)
-
-
-def get_local_rank() -> int:
-    return int(os.getenv("LOCAL_RANK", 0))
-
-
-def get_world_size() -> int:
-    return int(os.getenv("WORLD_SIZE", 1))

--- a/arctic_training/config/utils.py
+++ b/arctic_training/config/utils.py
@@ -23,6 +23,9 @@ class UniqueKeyLoader(yaml.SafeLoader):
         for key_node, _ in node.value:
             key = self.construct_object(key_node, deep=deep)
             if key in mapping:
-                raise ValueError(f"Duplicate {key!r} key found in YAML.")
+                raise ValueError(
+                    f"Duplicate '{key}' key found in YAML on line"
+                    f" {key_node.start_mark.line + 1}."
+                )
             mapping.add(key)
         return super().construct_mapping(node, deep)

--- a/arctic_training/utils.py
+++ b/arctic_training/utils.py
@@ -15,20 +15,6 @@
 
 import os
 
-import yaml
-
-
-# From https://gist.github.com/pypt/94d747fe5180851196eb?permalink_comment_id=4015118#gistcomment-4015118
-class UniqueKeyLoader(yaml.SafeLoader):
-    def construct_mapping(self, node, deep=False):
-        mapping = set()
-        for key_node, _ in node.value:
-            key = self.construct_object(key_node, deep=deep)
-            if key in mapping:
-                raise ValueError(f"Duplicate {key!r} key found in YAML.")
-            mapping.add(key)
-        return super().construct_mapping(node, deep)
-
 
 def get_local_rank() -> int:
     return int(os.getenv("LOCAL_RANK", 0))

--- a/tests/config/test_trainer_config.py
+++ b/tests/config/test_trainer_config.py
@@ -1,0 +1,32 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from arctic_training.config.trainer import get_config
+
+
+def test_duplicate_key_fail(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(
+        """
+        data:
+          max_length: 128
+          max_length: 256
+        """
+    )
+
+    with pytest.raises(ValueError, match=r"Duplicate .* key found"):
+        get_config(config_file)


### PR DESCRIPTION
`pyyaml` silently overwrites values in the config for duplicate keys. Adding a custom loader that errors when duplicate keys are detected in the input config. Resolves #85 