### PR TITLE
Allow CLI overrides of yaml config values

### DIFF
--- a/arctic_training/cli.py
+++ b/arctic_training/cli.py
@@ -23,6 +23,15 @@ from pathlib import Path
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("config", type=Path, help="ArticTraining config yaml file.")
+    parser.add_argument(
+        "--overrides",
+        nargs="+",
+        help=(
+            "Override config values. Provide a list of `key=value`, where '.' is used"
+            " to indicate nested keys. For example: --overrides epochs=10"
+            " model.dtype=FP32"
+        ),
+    )
     args, deepspeed_args = parser.parse_known_args()
 
     if not args.config.exists():
@@ -39,6 +48,8 @@ def main():
             exe_path,
             "--config",
             str(args.config),
+            "--overrides",
+            *args.overrides,
         ],
         env=env,
         check=True,
@@ -57,6 +68,15 @@ def run_script():
         type=Path,
         required=True,
         help="ArticTraining config to run.",
+    )
+    parser.add_argument(
+        "--overrides",
+        nargs="+",
+        help=(
+            "Override config values. Provide a list of `key=value`, where '.' is used"
+            " to indicate nested keys. For example: --overrides epochs=10"
+            " model.dtype=FP32"
+        ),
     )
     parser.add_argument(
         "--local_rank",


### PR DESCRIPTION
Adding the ability to override yaml config values via the CLI:

```shell
arctic_training my_config.yaml --overrides epochs=2 model.dtype=fp32 skip_validation=True
```

Currently a bit limited in that we can only override numeric, string, or boolean type config values. We might be able to extend this to other types if we think that would be useful.