### PR TITLE
Switch to DistributedSampler

### DIFF
--- a/arctic_training/config/data.py
+++ b/arctic_training/config/data.py
@@ -127,9 +127,6 @@ class DataConfig(BaseConfig):
     @model_validator(mode="after")
     def validate_cache_dir(self) -> Self:
         if not self.cache_dir.exists():
-            logger.info(
-                f"Caching directory {self.cache_dir} does not exist. Creating it."
-            )
             self.cache_dir.mkdir(parents=True, exist_ok=True)
         return self
 

--- a/arctic_training/config/data.py
+++ b/arctic_training/config/data.py
@@ -110,7 +110,7 @@ class DataConfig(BaseConfig):
     @model_validator(mode="after")
     def validate_cache_dir(self) -> Self:
         if not self.cache_dir.exists():
-            logger.warning(
+            logger.info(
                 f"Caching directory {self.cache_dir} does not exist. Creating it."
             )
             self.cache_dir.mkdir(parents=True, exist_ok=True)

--- a/arctic_training/config/data.py
+++ b/arctic_training/config/data.py
@@ -73,7 +73,7 @@ class DataConfig(BaseConfig):
     seed: int = 42
     """ Seed for data loading. """
 
-    use_data_cache: bool = True
+    use_data_cache: Optional[bool] = None
     """ Whether to cache loaded data. """
 
     cache_processed_data: Optional[bool] = None
@@ -86,13 +86,13 @@ class DataConfig(BaseConfig):
     def factory(self) -> Type["DataFactory"]:
         return get_registered_data_factory(self.type)
 
-    @field_validator("cache_processed_data", mode="after")
+    @field_validator("use_data_cache", "cache_processed_data", mode="after")
     @classmethod
     def deprecate_cache_processed_data(cls, v: Optional[bool]) -> Optional[bool]:
         if v is not None:
             logger.warning(
-                "The 'cache_processed_data' field is deprecated. Please use"
-                " 'use_data_cache' instead."
+                "The 'use_data_cache' and 'cache_processed_data' fields are deprecated."
+                " Data cache is used by default now."
             )
         return v
 
@@ -112,15 +112,11 @@ class DataConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_cache_dir(self) -> Self:
-        if self.use_data_cache:
-            assert (
-                self.cache_dir is not None
-            ), "You must provide a data_cache_dir if use_data_cache is True."
-            if not self.cache_dir.exists():
-                logger.warning(
-                    f"Caching directory {self.cache_dir} does not exist. Creating it."
-                )
-                self.cache_dir.mkdir(parents=True, exist_ok=True)
+        if not self.cache_dir.exists():
+            logger.warning(
+                f"Caching directory {self.cache_dir} does not exist. Creating it."
+            )
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
         return self
 
     @model_validator(mode="after")

--- a/arctic_training/config/data.py
+++ b/arctic_training/config/data.py
@@ -46,9 +46,6 @@ class DataSourceConfig(BaseConfig):
     process: bool = True
     """ Whether to process the data with the data factory `process` function (e.g., tokenization for SFTDataFactory). """
 
-    shard: bool = True
-    """ Whether to shard the data across Data Parallel process ranks. """
-
     @property
     def data_source(self) -> Type["DataSource"]:
         return get_registered_data_source(self.type)

--- a/arctic_training/data/factory.py
+++ b/arctic_training/data/factory.py
@@ -94,9 +94,8 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
 
             dist.barrier()  # Wait for the main process to finish its preprocessing + saving to cache
 
-            self.trainer._set_seeds(
-                self.trainer.config.seed
-            )  # Reset seeds before processing data
+            # Reset seeds after may be processing data if cache didn't exist - so that main process ends up with the same RNG if the cache was there and if it wasn't, thus ensuring reproducibility.
+            self.trainer._set_seeds(self.trainer.config.seed)
             logger.info(f"Loading dataset from cache path {cache_path.as_posix()}")
             return load_from_disk(cache_path.as_posix())
 

--- a/arctic_training/data/factory.py
+++ b/arctic_training/data/factory.py
@@ -80,7 +80,7 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
             data_sources = self._get_data_sources(split=split)
 
             cache_path = self.cache_path(sources=data_sources, split=split)
-            if self.config.use_data_cache and cache_path.exists():
+            if cache_path.exists():
                 logger.info(f"Loading dataset from cache path {cache_path.as_posix()}")
                 return load_from_disk(cache_path.as_posix())
 
@@ -89,9 +89,8 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
             dataset = self.load(data_sources, split=split)
             dataset = self._truncate_data(dataset)
 
-            if self.config.use_data_cache:
-                logger.info(f"Saving dataset to cache path {cache_path.as_posix()}")
-                dataset.save_to_disk(cache_path.as_posix())
+            logger.info(f"Saving dataset to cache path {cache_path.as_posix()}")
+            dataset.save_to_disk(cache_path.as_posix())
             return dataset
 
         training_data = get_data_split("train")

--- a/arctic_training/data/factory.py
+++ b/arctic_training/data/factory.py
@@ -92,7 +92,7 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
                 logger.info(f"Saving dataset to cache path {cache_path.as_posix()}")
                 dataset.save_to_disk(cache_path.as_posix())
 
-            dist.barrier()  # Wait for main process to finish saving to cache
+            dist.barrier()  # Wait for the main process to finish its preprocessing + saving to cache
 
             self.trainer._set_seeds(
                 self.trainer.config.seed

--- a/arctic_training/data/sft_factory.py
+++ b/arctic_training/data/sft_factory.py
@@ -23,7 +23,7 @@ import numpy as np
 import torch
 from datasets import Dataset
 from torch.utils.data import DataLoader
-from torch.utils.data import RandomSampler
+from torch.utils.data import DistributedSampler
 from tqdm import tqdm
 from transformers import BatchEncoding
 from transformers import PreTrainedTokenizerBase
@@ -367,7 +367,9 @@ class SFTDataFactory(DataFactory):
             dataset,
             collate_fn=DataCollatorForCausalLM(tokenizer=self.tokenizer),
             batch_size=self.micro_batch_size,
-            sampler=RandomSampler(dataset),
+            sampler=DistributedSampler(
+                dataset, num_replicas=self.world_size, rank=self.global_rank
+            ),
             num_workers=self.config.num_proc,
             drop_last=True,
         )

--- a/arctic_training/data/source.py
+++ b/arctic_training/data/source.py
@@ -61,7 +61,7 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
     def __call__(self, split: str) -> DatasetType:
         disable_caching()
         cache_path = self.cache_path(split)
-        if self.data_factory.config.use_data_cache and cache_path.exists():
+        if cache_path.exists():
             logger.info(f"Loading data source from cache path {cache_path.as_posix()}")
             return load_from_disk(cache_path.as_posix())
 
@@ -87,9 +87,8 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
                     f" {self.name} with config {self.config} for split {split}"
                 )
 
-        if self.data_factory.config.use_data_cache:
-            logger.info(f"Saving data source to cache path {cache_path.as_posix()}")
-            dataset.save_to_disk(cache_path.as_posix())
+        logger.info(f"Saving data source to cache path {cache_path.as_posix()}")
+        dataset.save_to_disk(cache_path.as_posix())
 
         return dataset
 

--- a/arctic_training/data/source.py
+++ b/arctic_training/data/source.py
@@ -117,6 +117,9 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
             "num_proc",
             "train_eval_split",
             "use_data_cache",
+            "world_size",
+            "global_rank",
+            "local_rank",
         }
         cache_path_args = (
             self.data_factory.config.model_dump(exclude=exclude_fields),

--- a/arctic_training/data/source.py
+++ b/arctic_training/data/source.py
@@ -71,14 +71,6 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
                 f"Empty dataset from load() for data source type {self.name} with"
                 f" config {self.config} for split {split}"
             )
-        if self.config.shard:
-            if len(dataset) < self.world_size:
-                raise ValueError(
-                    "Sharding is enabled but the dataset size is smaller than the"
-                    f" number of shards. Dataset size: {len(dataset)}, number of"
-                    f" shards: {self.world_size}"
-                )
-            dataset = dataset.shard(num_shards=self.world_size, index=self.global_rank)
         if self.config.process:
             dataset = self.data_factory.process(dataset)
             if len(dataset) < 1:

--- a/arctic_training/data/utils.py
+++ b/arctic_training/data/utils.py
@@ -14,13 +14,60 @@
 # limitations under the License.
 
 import hashlib
+from functools import cache
+from pathlib import Path
 from typing import Any
+from typing import Dict
 from typing import Union
 
+import psutil
 from datasets import Dataset
 from datasets import IterableDataset
 
 DatasetType = Union[Dataset, IterableDataset]
+
+
+@cache
+def _get_node_fs_types() -> Dict[Path, str]:
+    """Helper function to retrieve and cache filesystem types."""
+    return {Path(r.mountpoint): r.fstype for r in psutil.disk_partitions(all=True)}
+
+
+def _path_to_fs_type(path: Path) -> str:
+    """
+    Given a filesystem `path`, returns the filesystem type (ext, ext2, etc.).
+
+    Note: Non-existent paths will return the filesystem type of `/`.
+    """
+    path = path.resolve()
+
+    if path.is_symlink():
+        path = path.readlink()  # py3.9+
+
+    # Assuming at the end we percolate to `/` which is always there so the exit condition is assured
+    try:
+        return _get_node_fs_types()[path]
+    except KeyError:
+        return _path_to_fs_type(path.parent)
+
+
+def is_local_fs(path: Path) -> bool:
+    """Returns True if the `path` resides on a local filesystem, False otherwise."""
+    local_node_fs_types = [
+        "ext",
+        "ext2",
+        "ext3",
+        "ext4",
+        "reiserfs",
+        "jfs",
+        "xfs",
+        "zfs",
+        "xfs",
+        "btrfs",
+        "ntfs",
+        "overlay",
+    ]
+    return _path_to_fs_type(path) in local_node_fs_types
 
 
 def calculate_hash_from_args(*args: Any) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "loguru",
     "openai>=1.48.0",
     "peft",
+    "psutil",
     "pydantic>=2.0",
     "tabulate",
     "torch",

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -29,13 +29,12 @@ def create_sft_data_factory(
     model_name: str,
     sources: List[str],
     eval_sources: List[str] = [],
-    cache_dir: Optional[Path] = None,
+    cache_dir: Optional[Path] = Path("/tmp/"),
 ) -> SFTDataFactory:
     data_config = SFTDataConfig(
         type="sft",
         sources=sources,
         eval_sources=eval_sources,
-        use_data_cache=cache_dir is not None,
         cache_dir=cache_dir,
     )
     tokenizer_config = TokenizerConfig(type="huggingface", name_or_path=model_name)

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -45,6 +45,7 @@ def create_sft_data_factory(
             tokenizer=tokenizer_config,
         ),
         tokenizer=AutoTokenizer.from_pretrained(model_name),
+        _set_seeds=lambda seed: None,
     )
 
     data_factory = data_config.factory(trainer=dummy_trainer)

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -16,7 +16,6 @@
 from pathlib import Path
 from types import SimpleNamespace
 from typing import List
-from typing import Optional
 
 from transformers import AutoTokenizer
 
@@ -28,8 +27,8 @@ from arctic_training.data.sft_factory import SFTDataFactory
 def create_sft_data_factory(
     model_name: str,
     sources: List[str],
+    cache_dir: Path,
     eval_sources: List[str] = [],
-    cache_dir: Optional[Path] = Path("/tmp/"),
 ) -> SFTDataFactory:
     data_config = SFTDataConfig(
         type="sft",

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -46,6 +46,7 @@ def create_sft_data_factory(
         ),
         tokenizer=AutoTokenizer.from_pretrained(model_name),
         _set_seeds=lambda seed: None,
+        seed=42,
     )
 
     data_factory = data_config.factory(trainer=dummy_trainer)

--- a/tests/data/utils.py
+++ b/tests/data/utils.py
@@ -43,10 +43,10 @@ def create_sft_data_factory(
             micro_batch_size=1,
             data=data_config,
             tokenizer=tokenizer_config,
+            seed=42,
         ),
         tokenizer=AutoTokenizer.from_pretrained(model_name),
         _set_seeds=lambda seed: None,
-        seed=42,
     )
 
     data_factory = data_config.factory(trainer=dummy_trainer)


### PR DESCRIPTION
Previously we were pre-sharding loading datasets and saving to a cache file for each process. However, this is more cumbersome and error-prone than loading/processing data with a single process and using the DistributedSampler. Switching to use the DistributedSampler in this PR, which simplifies data loading and makes it more readable.

Other changes:
- Caching of datasets is now the default and only behavior supported
- Helper functions to detect local/shared filesystem to determine which ranks should load/process data