### PR TITLE
Allow local data files for huggingface data sources

### DIFF
--- a/arctic_training/config/data.py
+++ b/arctic_training/config/data.py
@@ -27,6 +27,7 @@ from pydantic import model_validator
 from typing_extensions import Self
 
 from arctic_training.config.base import BaseConfig
+from arctic_training.exceptions import RegistryError
 from arctic_training.logging import logger
 from arctic_training.registry import _get_class_attr_type_hints
 from arctic_training.registry import get_registered_data_factory
@@ -106,7 +107,11 @@ class DataConfig(BaseConfig):
         for config in v:
             # Support passing just a dataset name or path
             if isinstance(config, str):
-                config = dict(type=config, name_or_path=config)
+                try:
+                    _ = get_registered_data_source(config)
+                    config = dict(type=config, name_or_path=config)
+                except RegistryError:
+                    config = dict(type="huggingface", name_or_path=config)
 
             # Convert passed dictionary to DataSourceConfig subclass
             if isinstance(config, dict):

--- a/arctic_training/config/data.py
+++ b/arctic_training/config/data.py
@@ -41,7 +41,7 @@ class DataSourceConfig(BaseConfig):
     """Base DataSource configuration."""
 
     type: str = ""
-    """ Data source type. """
+    """ Data source type. Defaults to 'huggingface' if only a dataset name or path is provided."""
 
     process: bool = True
     """ Whether to process the data with the data factory `process` function (e.g., tokenization for SFTDataFactory). """
@@ -97,24 +97,18 @@ class DataConfig(BaseConfig):
         return v
 
     @field_validator("sources", "eval_sources", mode="before")
-    def create_source_config_from_name(
-        cls, v: List[Union[str, Dict, DataSourceConfig]]
-    ) -> List[Union[Dict, DataSourceConfig]]:
-        data_sources: List[Union[Dict, DataSourceConfig]] = []
-        for source in v:
-            if isinstance(source, str):
-                data_sources.append(dict(type=source))
-            else:
-                data_sources.append(source)
-        return data_sources
-
-    @field_validator("sources", "eval_sources", mode="before")
     def init_source_configs(
         cls,
-        v: List[Union[Dict, DataSourceConfig]],
+        v: List[Union[str, Dict, DataSourceConfig]],
     ) -> List[DataSourceConfig]:
+        """Convert string and dict input to correct subclass of DataSourceConfig. If a string is passed, "huggingface" is used as the DataSource type."""
         data_configs = []
         for config in v:
+            # Support passing just a dataset name or path
+            if isinstance(config, str):
+                config = dict(type=config, name_or_path=config)
+
+            # Convert passed dictionary to DataSourceConfig subclass
             if isinstance(config, dict):
                 if "type" not in config:
                     raise KeyError(

--- a/arctic_training/data/hf_source.py
+++ b/arctic_training/data/hf_source.py
@@ -88,7 +88,7 @@ class HFLocalDataSource(DataSource):
     config: HFLocalDataSourceConfig
 
     def load(self, config: HFLocalDataSourceConfig, split: str) -> DatasetType:
-        dataset = load_from_disk(config.path.as_posix())
+        dataset = load_from_disk(config.path.as_posix(), **config.kwargs)
         if isinstance(dataset, DatasetDict):
             return dataset[split]
         return dataset

--- a/tests/data/test_hf_source.py
+++ b/tests/data/test_hf_source.py
@@ -1,0 +1,62 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from datasets import Dataset
+from datasets import DatasetDict
+from datasets import load_dataset
+
+from .utils import create_sft_data_factory
+
+
+def test_huggingface_local_data_source(model_name: str, tmp_path: Path):
+    # Load small dataset and save locally with "train" split
+    dataset_path = tmp_path / "local_ultrachat"
+    dataset = load_dataset(
+        "HuggingFaceH4/ultrachat_200k", streaming=True, split="train_sft"
+    )
+    dataset = Dataset.from_list(list(dataset.take(20)), features=dataset.features)
+    DatasetDict(dict(train=dataset)).save_to_disk(dataset_path.as_posix())
+
+    # Load saved dataset using HuggingFaceLocal data source
+    sft_data_factory = create_sft_data_factory(
+        model_name=model_name,
+        sources=[dict(type="huggingface-local", path=dataset_path.as_posix())],
+        cache_dir=tmp_path,
+    )
+    training_dataloader, _ = sft_data_factory()
+
+    assert len(training_dataloader) > 0, "No data loaded"
+
+
+def test_huggingface_local_data_source_no_split(model_name: str, tmp_path: Path):
+    # Load small dataset and save locally without splits
+    dataset_path = tmp_path / "local_ultrachat"
+    dataset = load_dataset(
+        "HuggingFaceH4/ultrachat_200k", streaming=True, split="train_sft"
+    )
+    dataset = Dataset.from_list(list(dataset.take(20)), features=dataset.features)
+    dataset.save_to_disk(dataset_path.as_posix())
+
+    # Load saved dataset using HuggingFaceLocal data source
+    sft_data_factory = create_sft_data_factory(
+        model_name=model_name,
+        sources=[dict(type="huggingface-local", path=dataset_path.as_posix())],
+        cache_dir=tmp_path,
+    )
+    training_dataloader, _ = sft_data_factory()
+
+    assert len(training_dataloader) > 0, "No data loaded"

--- a/tests/data/test_hf_source.py
+++ b/tests/data/test_hf_source.py
@@ -34,7 +34,7 @@ def test_huggingface_local_data_source(model_name: str, tmp_path: Path):
     # Load saved dataset using HuggingFaceLocal data source
     sft_data_factory = create_sft_data_factory(
         model_name=model_name,
-        sources=[dict(type="huggingface", name_or_path=dataset_path.as_posix())],
+        sources=[dataset_path.as_posix()],
         cache_dir=tmp_path,
     )
     training_dataloader, _ = sft_data_factory()
@@ -54,7 +54,7 @@ def test_huggingface_local_data_source_no_split(model_name: str, tmp_path: Path)
     # Load saved dataset using HuggingFaceLocal data source
     sft_data_factory = create_sft_data_factory(
         model_name=model_name,
-        sources=[dict(type="huggingface", name_or_path=dataset_path.as_posix())],
+        sources=[dataset_path.as_posix()],
         cache_dir=tmp_path,
     )
     training_dataloader, _ = sft_data_factory()

--- a/tests/data/test_hf_source.py
+++ b/tests/data/test_hf_source.py
@@ -34,7 +34,7 @@ def test_huggingface_local_data_source(model_name: str, tmp_path: Path):
     # Load saved dataset using HuggingFaceLocal data source
     sft_data_factory = create_sft_data_factory(
         model_name=model_name,
-        sources=[dict(type="huggingface-local", path=dataset_path.as_posix())],
+        sources=[dict(type="huggingface", name_or_path=dataset_path.as_posix())],
         cache_dir=tmp_path,
     )
     training_dataloader, _ = sft_data_factory()
@@ -54,7 +54,7 @@ def test_huggingface_local_data_source_no_split(model_name: str, tmp_path: Path)
     # Load saved dataset using HuggingFaceLocal data source
     sft_data_factory = create_sft_data_factory(
         model_name=model_name,
-        sources=[dict(type="huggingface-local", path=dataset_path.as_posix())],
+        sources=[dict(type="huggingface", name_or_path=dataset_path.as_posix())],
         cache_dir=tmp_path,
     )
     training_dataloader, _ = sft_data_factory()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 from datasets import Dataset
 from datasets import IterableDataset
 from deepspeed.ops.adam import DeepSpeedCPUAdam
@@ -40,9 +42,9 @@ class RandomWeightHFModelFactory(HFModelFactory):
 
 def modify_config_for_truncated_data(self):
     self.config.kwargs["streaming"] = True  # Avoid downloading entire dataset
-    self.config.dataset_name = self.name.removesuffix(  # Set to the real dataset name
-        "-truncated"
-    )
+    self.config.name_or_path = Path(
+        str(self.config.name_or_path).removesuffix("-truncated")
+    )  # Set real dataset name
 
 
 def sample_data_for_truncated_dataset(self, dataset: IterableDataset) -> Dataset:


### PR DESCRIPTION
Allows loading of locally saved HF datasets. Example:
```yaml
data:
  sources:
    - type: huggingface # explicitly specify source type
      name_or_path: /path/to/dataset-1
    - /path/to-dataset-2 # also valid
```

To support this change, also added a pydantic validator for the `sources` and `eval_sources` fields that loads the correct config type for a given data source. Previously, we just defaulted to huggingface-hosted data sources.