### PR TITLE
Fix for cache path arg included values

### DIFF
--- a/arctic_training/config/base.py
+++ b/arctic_training/config/base.py
@@ -13,12 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from pydantic import BaseModel
 from pydantic import ConfigDict
-from pydantic import computed_field
+from pydantic import Field
 
+from arctic_training.config.utils import get_global_rank
+from arctic_training.config.utils import get_local_rank
+from arctic_training.config.utils import get_world_size
 from arctic_training.logging import logger
 
 
@@ -36,17 +37,6 @@ class BaseConfig(BaseModel):
         populate_by_name=True,
     )
 
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def local_rank(self) -> int:
-        return int(os.getenv("LOCAL_RANK", 0))
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def global_rank(self) -> int:
-        return int(os.getenv("RANK", 0))
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def world_size(self) -> int:
-        return int(os.getenv("WORLD_SIZE", 1))
+    local_rank: int = Field(default_factory=get_local_rank, exclude=True)
+    global_rank: int = Field(default_factory=get_global_rank, exclude=True)
+    world_size: int = Field(default_factory=get_world_size, exclude=True)

--- a/arctic_training/config/utils.py
+++ b/arctic_training/config/utils.py
@@ -13,7 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import yaml
+
+
+def get_local_rank() -> int:
+    return int(os.getenv("LOCAL_RANK", 0))
+
+
+def get_global_rank() -> int:
+    return int(os.getenv("RANK", 0))
+
+
+def get_world_size() -> int:
+    return int(os.getenv("WORLD_SIZE", 1))
 
 
 # From https://gist.github.com/pypt/94d747fe5180851196eb?permalink_comment_id=4015118#gistcomment-4015118

--- a/arctic_training/data/source.py
+++ b/arctic_training/data/source.py
@@ -117,9 +117,6 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
             "num_proc",
             "train_eval_split",
             "use_data_cache",
-            "world_size",
-            "global_rank",
-            "local_rank",
         }
         cache_path_args = (
             self.data_factory.config.model_dump(exclude=exclude_fields),


### PR DESCRIPTION
With the move to using distributed sampler, we want each rank to calculate the same cache path for a given data source. However a recent change in #102 that changed `local_rank`, `global_rank`, and `world_size` to being Pydantic computed_fields meant that these values were being included in the args that determine the cache path for a given data source. Reverting these changes and making those fields with `exclude=True` so they do not pollute the cache path args.