### PR TITLE
Add support for user-passed data splits

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -38,6 +38,11 @@ jobs:
         with:
           path: ~/.cache/torch_extensions
           key: torch-extensions-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ steps.get_latest_versions.outputs.versions }}
+      - name: Restore huggingface cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: huggingface-cache-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ steps.get_latest_versions.outputs.versions }}
       - name: Setup environment
         run: |
           python -m venv .venv

--- a/arctic_training/callback/mixin.py
+++ b/arctic_training/callback/mixin.py
@@ -131,7 +131,8 @@ class CallbackMixin:
             match = callback_re.match(name)
             if match:
                 event = f"{match.group(1)}-{match.group(2).replace('_', '-')}"
-                callbacks.append((event, member))
+                if (event, member) not in callbacks:
+                    callbacks.append((event, member))
 
         return callbacks
 

--- a/arctic_training/config/data.py
+++ b/arctic_training/config/data.py
@@ -22,8 +22,9 @@ from typing import Tuple
 from typing import Type
 from typing import Union
 
+from pydantic import ValidationInfo
 from pydantic import field_validator
-from pydantic import model_validator, ValidationInfo
+from pydantic import model_validator
 from typing_extensions import Self
 
 from arctic_training.config.base import BaseConfig

--- a/arctic_training/data/factory.py
+++ b/arctic_training/data/factory.py
@@ -31,6 +31,7 @@ from transformers import PreTrainedTokenizerBase
 from arctic_training.callback.mixin import CallbackMixin
 from arctic_training.callback.mixin import callback_wrapper
 from arctic_training.config.data import DataConfig
+from arctic_training.config.data import DataSourceConfig
 from arctic_training.data.utils import DatasetType
 from arctic_training.data.utils import calculate_hash_from_args
 from arctic_training.data.utils import is_local_fs
@@ -65,7 +66,7 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
     def _validate_subclass(cls) -> None:
         _validate_class_attribute_set(cls, "name")
         _validate_class_attribute_type(cls, "config", DataConfig)
-        _validate_class_method(cls, "load", ["self", "data_sources", "split"])
+        _validate_class_method(cls, "load", ["self", "data_sources"])
         _validate_class_method(cls, "process", ["self", "dataset"])
         _validate_class_method(cls, "split_data", ["self", "training_data"])
         _validate_class_method(cls, "create_dataloader", ["self", "dataset"])
@@ -78,17 +79,19 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
         self.config = config
 
     def __call__(self) -> Tuple[DataLoader, Optional[Mapping[str, DataLoader]]]:
-        def get_data_split(split: str) -> Optional[DatasetType]:
-            data_sources = self._get_data_sources(split=split)
-            if len(data_sources) == 0:
+        def load_data_sources(
+            data_source_configs: List[DataSourceConfig],
+        ) -> Optional[DatasetType]:
+            if len(data_source_configs) == 0:
                 return None
 
-            cache_path = self.cache_path(sources=data_sources, split=split)
+            data_sources = self._get_data_sources(data_source_configs)
+            cache_path = self.cache_path(sources=data_sources)
 
             # If the cache path does not exist, load the data using local/global
             # rank 0 (depending on if file system is shared across nodes).
             if self.is_main_process_by_path(cache_path) and not cache_path.exists():
-                dataset = self.load(data_sources, split=split)
+                dataset = self.load(data_sources)
                 logger.info(f"Saving dataset to cache path {cache_path.as_posix()}")
                 dataset.save_to_disk(cache_path.as_posix())
 
@@ -99,8 +102,8 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
             logger.info(f"Loading dataset from cache path {cache_path.as_posix()}")
             return load_from_disk(cache_path.as_posix())
 
-        training_data = get_data_split("train")
-        evaluation_data = get_data_split("eval")
+        training_data = load_data_sources(self.config.sources)
+        evaluation_data = load_data_sources(self.config.eval_sources)
 
         if self.config.train_eval_split[1] > 0.0:
             training_data, evaluation_data = self.split_data(training_data)
@@ -144,14 +147,9 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
         """The total number of processes in the world."""
         return self.config.world_size
 
-    def _get_data_sources(self, split: str) -> List["DataSource"]:
-        if split == "train":
-            data_source_configs = self.config.sources
-        elif split == "eval":
-            data_source_configs = self.config.eval_sources
-        else:
-            raise ValueError(f"Invalid split: {split}")
-
+    def _get_data_sources(
+        self, data_source_configs: List[DataSourceConfig]
+    ) -> List["DataSource"]:
         data_sources = []
         for config in data_source_configs:
             data_source = config.data_source(data_factory=self, config=config)
@@ -163,18 +161,18 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
             return self.local_rank == 0
         return self.global_rank == 0
 
-    def cache_path(self, sources: List["DataSource"], split: str) -> Path:
+    def cache_path(self, sources: List["DataSource"]) -> Path:
         """Returns the cache path for the processed + concatenated dataset."""
         source_cache_path_args = (s.cache_path_args for s in sources)
-        hash_str = calculate_hash_from_args(split, *source_cache_path_args)
+        hash_str = calculate_hash_from_args(*source_cache_path_args)
         return self.config.cache_dir / hash_str
 
     @callback_wrapper("load")
-    def load(self, data_sources: List["DataSource"], split: str) -> DatasetType:
+    def load(self, data_sources: List["DataSource"]) -> DatasetType:
         """Loads data from one or more data sources and concatenates into a single dataset."""
         datasets = []
         for data_source in data_sources:
-            dataset = data_source(split)
+            dataset = data_source()
             datasets.append(dataset)
         dataset = concatenate_datasets(datasets)
         return dataset

--- a/arctic_training/data/hf_source.py
+++ b/arctic_training/data/hf_source.py
@@ -62,8 +62,10 @@ class UltraChat200K(HFDataSource):
     name = "HuggingFaceH4/ultrachat_200k"
 
     def pre_load_callback(self, split: str) -> str:
-        split_map = {"train": "train_sft", "test": "test_sft"}
-        return split_map.get(split, split)
+        split_map = dict(train="train_sft", eval="test_sft")
+        for original, modified in split_map.items():
+            split = split.replace(original, modified)
+        return split
 
 
 class SlimOrca(HFDataSource):

--- a/arctic_training/data/hf_source.py
+++ b/arctic_training/data/hf_source.py
@@ -29,7 +29,10 @@ from arctic_training.data.utils import DatasetType
 
 class HFDataSourceConfig(DataSourceConfig):
     name_or_path: Path
-    """ Name of the dataset to load. """
+    """
+    Name or path of the dataset to load. Also accepts values for the split field
+    after a colon (e.g. "name:split", "name:split[10:20]").
+    """
 
     kwargs: Dict[str, Any] = {}
     """ Keyword arguments to pass to the datasets.load_dataset function. """

--- a/tests/data/test_sft_factory.py
+++ b/tests/data/test_sft_factory.py
@@ -24,9 +24,12 @@ from .utils import create_sft_data_factory
 @pytest.mark.parametrize(
     "training_sources, expected_sum",
     [
-        (["HuggingFaceH4/ultrachat_200k-truncated"], 487103798),
+        (["HuggingFaceH4/ultrachat_200k:train[:20]"], 487103798),
         (
-            ["HuggingFaceH4/ultrachat_200k-truncated", "Open-Orca/SlimOrca-truncated"],
+            [
+                "HuggingFaceH4/ultrachat_200k:train[:20]",
+                "Open-Orca/SlimOrca:train[:20]",
+            ],
             591408621,
         ),
     ],
@@ -53,8 +56,8 @@ def test_generated_data(
 
 def test_sft_factory_cache_path_uniqueness(model_name: str, tmp_path: Path):
     data_sources = [
-        "HuggingFaceH4/ultrachat_200k-truncated",
-        "Open-Orca/SlimOrca-truncated",
+        "HuggingFaceH4/ultrachat_200k",
+        "Open-Orca/SlimOrca",
     ]
     data_factory_1 = create_sft_data_factory(
         model_name=model_name, sources=data_sources, cache_dir=tmp_path
@@ -66,10 +69,10 @@ def test_sft_factory_cache_path_uniqueness(model_name: str, tmp_path: Path):
     )
 
     cache_path_1 = data_factory_1.cache_path(
-        data_factory_1._get_data_sources(split="train"), "train"
+        data_factory_1._get_data_sources(data_factory_1.config.sources)
     )
     cache_path_2 = data_factory_2.cache_path(
-        data_factory_2._get_data_sources(split="train"), "train"
+        data_factory_2._get_data_sources(data_factory_2.config.sources)
     )
 
     assert cache_path_1 != cache_path_2, "Cache paths were not unique"

--- a/tests/data/test_source.py
+++ b/tests/data/test_source.py
@@ -31,8 +31,12 @@ def test_data_source_cache_path_uniqueness(model_name: str, tmp_path: Path):
     )
 
     cache_paths = [
-        s.cache_path("train") for s in data_factory._get_data_sources("train")
-    ] + [s.cache_path("eval") for s in data_factory._get_data_sources("eval")]
+        s.cache_path
+        for s in data_factory._get_data_sources(data_factory.config.sources)
+    ] + [
+        s.cache_path
+        for s in data_factory._get_data_sources(data_factory.config.eval_sources)
+    ]
     assert len(cache_paths) == 2 * len(
         data_sources
     ), "Cache paths were not generated for all data sources"

--- a/tests/trainer/test_sft_trainer.py
+++ b/tests/trainer/test_sft_trainer.py
@@ -32,7 +32,7 @@ def test_sft_trainer(model_name):
         },
         "data": {
             "max_length": 2048,
-            "sources": ["HuggingFaceH4/ultrachat_200k-truncated"],
+            "sources": ["HuggingFaceH4/ultrachat_200k:train[:20]"],
         },
     }
 
@@ -56,7 +56,7 @@ def test_sft_trainer_cpu(model_name):
         },
         "data": {
             "max_length": 2048,
-            "sources": ["HuggingFaceH4/ultrachat_200k-truncated"],
+            "sources": ["HuggingFaceH4/ultrachat_200k:train[:20]"],
         },
         "deepspeed": {
             "zero_optimization": {


### PR DESCRIPTION
Add support for user-passed split value in data sources. This allows greater flexibility to control which split (if there are multiple splits in a dataset) and how much data is returned from each data source. For `HFDataSource` the split supports [slice splits](https://huggingface.co/docs/datasets/en/loading#slice-splits):
```yaml
data:
  sources:
    - HuggingFaceH4/ultrachat_200k:train[:20]
    - type: huggingface
      name_or_path: Open-Orca/SlimOrca
      split: test[10:50]
```