### PR TITLE
Add dev flag to repeat data samples

### DIFF
--- a/arctic_training/config/data.py
+++ b/arctic_training/config/data.py
@@ -89,6 +89,13 @@ class DataConfig(BaseConfig):
     cache_dir: Path = Path("/tmp/")
     """ Directory to store cached data. """
 
+    expand_to_dp_size: bool = False
+    """
+    Repeats the loaded data until there is one sample per data parallel process
+    when the loaded dataset size is smaller than the data parallel size. Useful
+    for development and debugging work.
+    """
+
     @property
     def factory(self) -> Type["DataFactory"]:
         return get_registered_data_factory(self.type)

--- a/arctic_training/data/factory.py
+++ b/arctic_training/data/factory.py
@@ -92,6 +92,21 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
             # rank 0 (depending on if file system is shared across nodes).
             if self.is_main_process_by_path(cache_path) and not cache_path.exists():
                 dataset = self.load(data_sources)
+
+                if len(dataset) < self.world_size:
+                    if not self.config.expand_to_dp_size:
+                        raise ValueError(
+                            f"Dataset size ({len(dataset)}) is less than the data"
+                            f" parallel size ({self.world_size}). For development and"
+                            " debugging work, you can set expand_to_dp_size to True in"
+                            " the data config to repeat the dataset until it matches"
+                            " the data parallel size to ensure at least 1 sample per"
+                            " data parallel process."
+                        )
+                    num_repeats = self.world_size // len(dataset) + 1
+                    dataset = concatenate_datasets([dataset] * num_repeats)
+                    dataset = dataset.sample(range(self.world_size))
+
                 logger.info(f"Saving dataset to cache path {cache_path.as_posix()}")
                 dataset.save_to_disk(cache_path.as_posix())
 


### PR DESCRIPTION
In some cases for development and debugging work, we want to load a small amount of data and repeat it until we have at least 1 sample per data parallel process. Adding `expand_to_dp_size` flag to the data config to enable this behavior.