### PR TITLE
Update DPO liger loss check

### DIFF
--- a/arctic_training/trainer/dpo_trainer.py
+++ b/arctic_training/trainer/dpo_trainer.py
@@ -280,7 +280,7 @@ class DPOTrainer(Trainer):
         logits, logprobs, _, hidden_state = self.forward_model(batch)
 
         # Activate if we have liger kernel
-        if self.liger_dpo_loss:
+        if self.liger_dpo_loss not None:
             losses, _, _ = self.liger_dpo_loss(
                 hidden_state,
                 self.model.module.lm_head.weight,

--- a/arctic_training/trainer/dpo_trainer.py
+++ b/arctic_training/trainer/dpo_trainer.py
@@ -280,7 +280,7 @@ class DPOTrainer(Trainer):
         logits, logprobs, _, hidden_state = self.forward_model(batch)
 
         # Activate if we have liger kernel
-        if self.liger_dpo_loss not None:
+        if self.liger_dpo_loss is not None:
             losses, _, _ = self.liger_dpo_loss(
                 hidden_state,
                 self.model.module.lm_head.weight,


### PR DESCRIPTION
Generally it's better to do `if x is not None` rather than `if x`. Small change to fix this in latest DPO release.