### PR TITLE
Small improvements / fixes for metrics logging

### DIFF
--- a/arctic_training/config/logger.py
+++ b/arctic_training/config/logger.py
@@ -53,7 +53,7 @@ class LoggerConfig(BaseConfig):
 
     @property
     def log_file(self) -> Path:
-        return self.output_dir / f"rank_{self.local_rank}.log"
+        return self.output_dir / "logs" / f"rank_{self.local_rank}.log"
 
     @property
     def file_enabled(self) -> bool:

--- a/arctic_training/metrics.py
+++ b/arctic_training/metrics.py
@@ -116,6 +116,10 @@ class Metrics:
         """Returns the value stored in the metrics dictionary for the given key."""
         return self.values[key]
 
+    def get_summary_dict(self, exclude: List[str] = []) -> Dict[str, Union[int, float]]:
+        """Returns a copy of the summary dictionary."""
+        return {k: v for k, v in self.summary_dict.items() if k not in exclude}
+
     def print_summary(self) -> None:
         """Prints a summary of the metrics. If a value is not recorded by the Trainer, it is not included in the summary."""
         if not self.enabled:
@@ -166,24 +170,25 @@ class Metrics:
 
         self.values.clear()
 
-        summary_str = f"epoch: {self.summary_dict['epoch']}"
-        summary_str += (
-            " | iter:"
+        summary_str = (
+            "iter:"
             f" {self.summary_dict['iter']:>{self.max_iter_pad}}/{self.max_iter}"
             f" ({100*self.summary_dict['iter']//self.max_iter:>3}%)"
         )
         if "loss" in self.summary_dict:
             summary_str += f" | loss: {self.summary_dict['loss']:.4f}"
         if "iter_time" in self.summary_dict:
-            summary_str += f" | iter time: {self.summary_dict['iter_time']:.3f} s"
+            summary_str += f" | iter time: {self.summary_dict['iter_time']:.1f} s"
         if "iter_tflops" in self.summary_dict:
             summary_str += f" | iter tflops: {self.summary_dict['iter_tflops']:.1f}"
         summary_str += f" | lr: {self.summary_dict['lr']:.3E}"
         if "seqlen_total" in self.summary_dict:
             summary_str += f" | seqlen total: {self.summary_dict['seqlen_total']:.1f}"
         if "step_time" in self.summary_dict:
-            summary_str += f" | step time: {self.summary_dict['step_time']:.3f} s"
+            summary_str += f" | step time: {self.summary_dict['step_time']:.1f} s"
         if "step_tflops" in self.summary_dict:
             summary_str += f" | step tflops: {self.summary_dict['step_tflops']:.1f}"
+        summary_str += f" | epoch: {self.summary_dict['epoch']}"
 
-        print(summary_str)
+        if self.trainer.global_rank == 0:
+            print(summary_str)

--- a/arctic_training/metrics.py
+++ b/arctic_training/metrics.py
@@ -173,7 +173,7 @@ class Metrics:
         summary_str = (
             "iter:"
             f" {self.summary_dict['iter']:>{self.max_iter_pad}}/{self.max_iter}"
-            f" ({100*self.summary_dict['iter']//self.max_iter:>3}%)"
+            f" {100*self.summary_dict['iter']//self.max_iter:>3}%"
         )
         if "loss" in self.summary_dict:
             summary_str += f" | loss: {self.summary_dict['loss']:.4f}"

--- a/arctic_training/metrics.py
+++ b/arctic_training/metrics.py
@@ -116,10 +116,6 @@ class Metrics:
         """Returns the value stored in the metrics dictionary for the given key."""
         return self.values[key]
 
-    def get_summary_dict(self, exclude: List[str] = []) -> Dict[str, Union[int, float]]:
-        """Returns a copy of the summary dictionary."""
-        return {k: v for k, v in self.summary_dict.items() if k not in exclude}
-
     def print_summary(self) -> None:
         """Prints a summary of the metrics. If a value is not recorded by the Trainer, it is not included in the summary."""
         if not self.enabled:

--- a/arctic_training/metrics.py
+++ b/arctic_training/metrics.py
@@ -23,6 +23,8 @@ from typing import cast
 import torch
 from deepspeed.utils.timer import SynchronizedWallClockTimer
 
+from arctic_training.utils import human_format_base10_number
+
 if TYPE_CHECKING:
     from arctic_training.trainer.trainer import Trainer
 
@@ -160,7 +162,7 @@ class Metrics:
             summary_str += f" | iter tflops: {self.summary_dict['iter_tflops']:.1f}"
         summary_str += f" | lr: {self.summary_dict['lr']:.3E}"
         if "seqlen_total" in self.summary_dict:
-            summary_str += f" | seqlen total: {self.summary_dict['seqlen_total']:.1f}"
+            summary_str += f" | seqlen total: {human_format_base10_number(self.summary_dict['seqlen_total'])}"
         if "step_time" in self.summary_dict:
             summary_str += f" | step time: {self.summary_dict['step_time']:.1f} s"
         if "step_tflops" in self.summary_dict:

--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -322,7 +322,7 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
                 self.metrics.print_summary()
                 if (
                     self.global_rank == 0
-                    and self.train_batch_idx > 0
+                    and self.train_batch_idx > 1  # first iter is a massive outlier
                     and self.wandb_experiment is not None
                 ):
                     self.wandb_experiment.log(

--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -315,11 +315,7 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
                     and self.wandb_experiment is not None
                 ):
                     self.wandb_experiment.log(
-                        {
-                            k: v
-                            for k, v in self.metrics.summary_dict.items()
-                            if k != "iter"
-                        },
+                        {k: v for k, v in self.metrics.summary_dict.items() if k != "iter"},
                         step=self.model.global_steps,
                     )
 

--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -315,11 +315,15 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
 
             self.metrics.restart_timer("iter")
 
-            if self.train_batch_idx % self.config.train_log_iter_interval == 0:
+            if (
+                self.config.train_log_iter_interval != 0
+                and self.train_batch_idx % self.config.train_log_iter_interval == 0
+            ):
                 self.metrics.print_summary()
-                if self.wandb_experiment is not None:
+                if self.global_rank == 0 and self.wandb_experiment is not None:
                     self.wandb_experiment.log(
-                        self.metrics.summary_dict, step=self.model.global_steps
+                        self.metrics.get_summary_dict(exclude=["iter", "epoch"]),
+                        step=self.model.global_steps,
                     )
 
             if self.early_stop:

--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -320,9 +320,17 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
                 and self.train_batch_idx % self.config.train_log_iter_interval == 0
             ):
                 self.metrics.print_summary()
-                if self.global_rank == 0 and self.wandb_experiment is not None:
+                if (
+                    self.global_rank == 0
+                    and self.train_batch_idx > 0
+                    and self.wandb_experiment is not None
+                ):
                     self.wandb_experiment.log(
-                        self.metrics.get_summary_dict(exclude=["iter", "epoch"]),
+                        {
+                            k: v
+                            for k, v in self.metrics.summary_dict.items()
+                            if k != "iter"
+                        },
                         step=self.model.global_steps,
                     )
 

--- a/arctic_training/utils.py
+++ b/arctic_training/utils.py
@@ -21,7 +21,7 @@ def human_format_base2_number(num: float, suffix: str = "") -> str:
         return f"0{suffix}"
 
     units = ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"]
-    exponent = min(int(math.log(num, 1024)), len(units) - 1)
+    exponent = min(int(math.log(abs(num), 1024)), len(units) - 1)
     value = num / (1024**exponent)
 
     return f"{value:_.1f}{units[exponent]}{suffix}"
@@ -32,7 +32,7 @@ def human_format_base10_number(num: float, suffix: str = "") -> str:
         return f"0{suffix}"
 
     units = ["", "K", "M", "B", "T", "Qa", "Qi"]  # Qa: Quadrillion, Qi: Quintillion
-    exponent = min(int(math.log(num, 1000)), len(units) - 1)
+    exponent = min(int(math.log(abs(num), 1000)), len(units) - 1)
     value = num / (1000**exponent)
 
     return f"{value:_.1f}{units[exponent]}{suffix}"

--- a/arctic_training/utils.py
+++ b/arctic_training/utils.py
@@ -1,0 +1,38 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+
+def human_format_base2_number(num: float, suffix: str = "") -> str:
+    if num == 0:
+        return f"0{suffix}"
+
+    units = ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi", "Yi"]
+    exponent = min(int(math.log(num, 1024)), len(units) - 1)
+    value = num / (1024**exponent)
+
+    return f"{value:_.1f}{units[exponent]}{suffix}"
+
+
+def human_format_base10_number(num: float, suffix: str = "") -> str:
+    if num == 0:
+        return f"0{suffix}"
+
+    units = ["", "K", "M", "B", "T", "Qa", "Qi"]  # Qa: Quadrillion, Qi: Quintillion
+    exponent = min(int(math.log(num, 1000)), len(units) - 1)
+    value = num / (1000**exponent)
+
+    return f"{value:_.1f}{units[exponent]}{suffix}"


### PR DESCRIPTION
- Move output log files to a `logs/` subdir
- Ensure only global rank 0 is logging to W&B / printing
- Remove `step` and `epoch` from W&B reported values to avoid plots like step vs step
- Move `epochs` to end of logging line
- Reduce precision to more reasonable values for reported times
- Add human-readable formatting util functions