### PR TITLE
 metrics: seqlen report

### DIFF
--- a/arctic_training/metrics.py
+++ b/arctic_training/metrics.py
@@ -139,7 +139,7 @@ class Metrics:
 
         if "seqlen" in self.values:
             seq_len_total = sum(gather_object(self.values["seqlen"], self.trainer.world_size))
-            self.summary_dict["seqlen_total"] = seq_len_total
+            self.summary_dict["seqlen"] = seq_len_total / self.trainer.world_size
 
         if "step_time" in self.values:
             step_time_total = sum(gather_object(self.values["step_time"], self.trainer.world_size))
@@ -161,8 +161,8 @@ class Metrics:
         if "iter_tflops" in self.summary_dict:
             summary_str += f" | iter tflops: {self.summary_dict['iter_tflops']:.1f}"
         summary_str += f" | lr: {self.summary_dict['lr']:.3E}"
-        if "seqlen_total" in self.summary_dict:
-            summary_str += f" | seqlen total: {human_format_base10_number(self.summary_dict['seqlen_total'])}"
+        if "seqlen" in self.summary_dict:
+            summary_str += f" | seqlen: {human_format_base10_number(self.summary_dict['seqlen'])}"
         if "step_time" in self.summary_dict:
             summary_str += f" | step time: {self.summary_dict['step_time']:.1f} s"
         if "step_tflops" in self.summary_dict:


### PR DESCRIPTION
I realized seqlen total per iteration is a useless metric, so switching to report the average seqlen, which is meaningful. 

later seen_tokens will be ~ `seqlen_total*iterations` and then it'd be meaningful again.

cc: @sfc-gh-mwyatt