### PR TITLE
metrics: better seconds formatting

### DIFF
--- a/arctic_training/metrics.py
+++ b/arctic_training/metrics.py
@@ -24,6 +24,7 @@ import torch
 from deepspeed.utils.timer import SynchronizedWallClockTimer
 
 from arctic_training.utils import human_format_base10_number
+from arctic_training.utils import human_format_secs
 
 if TYPE_CHECKING:
     from arctic_training.trainer.trainer import Trainer
@@ -157,14 +158,14 @@ class Metrics:
         if "loss" in self.summary_dict:
             summary_str += f" | loss: {self.summary_dict['loss']:.4f}"
         if "iter_time" in self.summary_dict:
-            summary_str += f" | iter time: {self.summary_dict['iter_time']:.1f} s"
+            summary_str += f" | iter time: {human_format_secs(self.summary_dict['iter_time'])}"
         if "iter_tflops" in self.summary_dict:
             summary_str += f" | iter tflops: {self.summary_dict['iter_tflops']:.1f}"
         summary_str += f" | lr: {self.summary_dict['lr']:.3E}"
         if "seqlen" in self.summary_dict:
             summary_str += f" | seqlen: {human_format_base10_number(self.summary_dict['seqlen'])}"
         if "step_time" in self.summary_dict:
-            summary_str += f" | step time: {self.summary_dict['step_time']:.1f} s"
+            summary_str += f" | step time: {human_format_secs(self.summary_dict['step_time'])}"
         if "step_tflops" in self.summary_dict:
             summary_str += f" | step tflops: {self.summary_dict['step_tflops']:.1f}"
         summary_str += f" | epoch: {self.summary_dict['epoch']}"

--- a/arctic_training/utils.py
+++ b/arctic_training/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import math
 
 
@@ -36,3 +37,15 @@ def human_format_base10_number(num: float, suffix: str = "") -> str:
     value = num / (1000**exponent)
 
     return f"{value:_.2f}{units[exponent]}{suffix}"
+
+
+def human_format_secs(secs):
+    """
+    - less than a minute format into seconds with decimals: "%s.%msec"
+    - one minute and over use "%H:%M:%S" format
+    - if over one day use: "X days, %H:%M:%S" format
+    """
+    if secs < 60:
+        return f"{secs:.3f}s"
+    else:
+        return str(datetime.timedelta(seconds=secs)).split(".")[0]


### PR DESCRIPTION
Changing the secs format to do `%H:%M:%S` when it's more than 1 minute - e.g. 1M+ ulysses is ~3h step.

Here are examples of output after the change:

`<1min`:
```
iter:  1/50   2% | loss: 6.9812 | iter time: 40.219s | iter tflops: 2.8 | lr: 4.167E-07 | seqlen: 7.71K | step time: 38.539s | step tflops: 2.9 | epoch: 0
iter:  2/50   4% | loss: 7.0292 | iter time: 6.913s | iter tflops: 15.2 | lr: 8.333E-07 | seqlen: 7.42K | step time: 6.898s | step tflops: 15.3 | epoch: 0
iter:  3/50   6% | loss: 7.2154 | iter time: 7.107s | iter tflops: 15.3 | lr: 1.250E-06 | seqlen: 7.58K | step time: 7.062s | step tflops: 15.4 | epoch: 0
```
`>1min`:
```
iter:  1/50   2% | loss: 8.2158 | iter time: 0:02:35 | iter tflops: 302.4 | lr: 1.000E-06 | seqlen: 249.18K | step time: 0:02:31 | step tflops: 309.3 | epoch: 0
iter:  2/50   4% | loss: 8.1467 | iter time: 0:01:41 | iter tflops: 464.5 | lr: 2.000E-06 | seqlen: 249.18K | step time: 0:01:41 | step tflops: 464.7 | epoch: 0
iter:  3/50   6% | loss: 8.1814 | iter time: 0:01:42 | iter tflops: 458.9 | lr: 3.000E-06 | seqlen: 249.82K | step time: 0:01:42 | step tflops: 459.0 | epoch: 0
```

the only potential non-smooth thing will be if some training hovers around 1min - then it'd switch back and forth between 2 formats. Perhaps we could cache which format was used the first time and stick to it through? can improve in the future if it's bothersome.

cc: @sfc-gh-mwyatt 