### PR TITLE
fix multi-epoch training

### DIFF
--- a/arctic_training/checkpoint/engine.py
+++ b/arctic_training/checkpoint/engine.py
@@ -99,9 +99,7 @@ class CheckpointEngine(ABC, CallbackMixin, metaclass=RegistryMeta):
         ):
             return_value = self.trainer.global_step % self.config.save_every_n_steps == 0
         if self.config.save_every_n_epochs:
-            return_value = self.epoch_finished and (
-                self.trainer.epoch_idx % self.config.save_every_n_epochs
-            ) == 0
+            return_value = self.epoch_finished and (self.trainer.epoch_idx % self.config.save_every_n_epochs) == 0
         if self.config.save_end_of_training:
             return_value = return_value or self.training_finished
         return return_value

--- a/arctic_training/checkpoint/engine.py
+++ b/arctic_training/checkpoint/engine.py
@@ -76,6 +76,10 @@ class CheckpointEngine(ABC, CallbackMixin, metaclass=RegistryMeta):
         return self.trainer.device
 
     @property
+    def epoch_finished(self) -> bool:
+        return self.trainer.epoch_finished
+
+    @property
     def training_finished(self) -> bool:
         return self.trainer.training_finished
 
@@ -95,7 +99,7 @@ class CheckpointEngine(ABC, CallbackMixin, metaclass=RegistryMeta):
         ):
             return_value = self.trainer.global_step % self.config.save_every_n_steps == 0
         if self.config.save_every_n_epochs:
-            return_value = (self.trainer.epoch_idx > 0) and (
+            return_value = self.epoch_finished and (
                 self.trainer.epoch_idx % self.config.save_every_n_epochs
             ) == 0
         if self.config.save_end_of_training:

--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -151,6 +151,7 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
         self.early_stop = False
         self.world_size = config.world_size
         self.global_rank = config.global_rank
+        self.epoch_finished = False
         self.training_finished = False
         self.wandb_experiment: Optional[WandbRun] = None
 
@@ -294,6 +295,7 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
         training and iterates across batches of training data, calling the step
         method on each batch.
         """
+        self.epoch_finished = False
         self.metrics.start_timer("iter")
         for batch in self.train_batches:
             self.train_batch_idx += 1
@@ -322,6 +324,8 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
 
             if self.early_stop:
                 break
+        self.metrics.stop_timer("iter")
+        self.epoch_finished = True
 
     @callback_wrapper("train")
     def train(self) -> None:


### PR DESCRIPTION
Fix two bugs causing multi-epoch training to fail:

- iter timer doesn't get stopped after the epoch which causes the start of the next epoch to crash
- if save_every_n_epochs is set, will start to save a checkpoint every step after the first epoch