### PR TITLE
[Makefile] new optional helper to remove unused imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,8 @@ format: ## fix formatting
                 deactivate; \
 	fi
 	. venv/bin/activate && pre-commit run --all-files && deactivate
+
+# this tool is optional not to be run automatically as it could have unexpected side-effects, but is useful when
+# needing to remove a bulk of unused imports
+autoflake: ## autoremove unused imports (careful!)
+	autoflake --quiet --in-place --remove-all-unused-imports --ignore-init-module-imports --ignore-pass-after-docstring -r arctic_training

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ testing = [
 
 formatting = [
     "pre-commit",
+    "autoflake",
 ]
 
 docs = [


### PR DESCRIPTION
this is superuseful when mixing or splicing many py files together to quickly remove unused imports.

but it could have bad side-effects, so making it into an optional target to be used only when it's really saving time.

cc: @sfc-gh-mwyatt