### PR TITLE
an optional mem profiler

### DIFF
--- a/arctic_training/config/trainer.py
+++ b/arctic_training/config/trainer.py
@@ -139,6 +139,9 @@ class TrainerConfig(BaseConfig):
     mem_profiler_dir: Path = Field(default_factory=lambda data: data["logger"].output_dir / "mem-prof")
     """ Path to save memory profiling results. Defaults to `logger.output_dir/mem-prof`. """
 
+    mem_profiler_max_entries: int = Field(default=100_000, ge=1)
+    """ Maximum number of entries to store in the memory profiler. """
+
     @model_validator(mode="after")
     def init_dist(self) -> Self:
         get_accelerator().set_device(self.local_rank)

--- a/arctic_training/config/trainer.py
+++ b/arctic_training/config/trainer.py
@@ -133,6 +133,12 @@ class TrainerConfig(BaseConfig):
     overfit_first_batch: bool = False
     """ Train only on repetitions of the first training batch. Useful for development. """
 
+    mem_profiler: Literal[None, "step", "e2e"] = None
+    """ Enable memory profiling. """
+
+    mem_profiler_dir: Path = Field(default_factory=lambda data: data["logger"].output_dir / "mem-prof")
+    """ Path to save memory profiling results. Defaults to `logger.output_dir/mem-prof`. """
+
     @model_validator(mode="after")
     def init_dist(self) -> Self:
         get_accelerator().set_device(self.local_rank)
@@ -332,6 +338,12 @@ class TrainerConfig(BaseConfig):
     def validate_single_checkpoint_resume(self) -> Self:
         resume_checkpoint_values = [c.auto_resume for c in self.checkpoint]
         assert sum(resume_checkpoint_values) <= 1, "Only one checkpoint can auto resume."
+        return self
+
+    @model_validator(mode="after")
+    def mem_profiler_mkdir(self) -> Self:
+        if self.mem_profiler is not None:
+            self.mem_profiler_dir.mkdir(parents=True, exist_ok=True)
         return self
 
 

--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -154,7 +154,7 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
         self._set_seeds(self.config.seed)
 
         if self.config.mem_profiler == "e2e":
-            torch.cuda.memory._record_memory_history(max_entries=100_000)
+            torch.cuda.memory._record_memory_history(max_entries=self.config.mem_profiler_max_entries)
 
         tokenizer_factory = self.config.tokenizer.factory(self)
         self.tokenizer = tokenizer_factory()
@@ -299,7 +299,7 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
 
         # enable memory history, which will add tracebacks and event history to snapshots
         if self.config.mem_profiler == "step":
-            torch.cuda.memory._record_memory_history(max_entries=100_000)
+            torch.cuda.memory._record_memory_history(max_entries=self.config.mem_profiler_max_entries)
 
         for batch in self.train_batches:
             self.train_batch_idx += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "openai>=1.48.0",
     "peft",
     "psutil",
-    "pydantic>=2.0",
+    "pydantic>=2.10",
     "tabulate",
     "torch",
     "tqdm",


### PR DESCRIPTION
@sfc-gh-mwyatt, let's make this configurable?

3 settings:
1. at which level to bracket the profiling - at the moment I added "e2e" (all of it) vs "step" - only around the step
2. how many items to store - currently between 100k and 1m (hardcoded at the moment) `torch.cuda.memory._record_memory_history(max_entries=100_000)`
3. where to save the results 

Actually probably should `s/step/epoch/` as it's measuring at the level of epoch.

we can discuss the naming next and/or feel free to push directly into this PR.