### PR TITLE
train iter log: add mem metrics

### DIFF
--- a/arctic_training/debug.py
+++ b/arctic_training/debug.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import gc
+
+import pynvml
+
+# deepspeed or
+import torch.distributed as dist
+from deepspeed.accelerator import get_accelerator
+
+pynvml_handle = None
+
+
+def get_mem_metrics():
+    global pynvml_handle
+
+    gc.collect()
+
+    if pynvml_handle is None:
+        pynvml.nvmlInit()
+        rank = dist.get_rank() if dist.is_initialized() else 0
+        pynvml_handle = pynvml.nvmlDeviceGetHandleByIndex(rank)
+        # pynvml.nvmlShutdown()
+    memory_info = pynvml.nvmlDeviceGetMemoryInfo(pynvml_handle)
+    nv_mem = memory_info.used
+
+    summary = " | ".join(
+        [
+            f"MA {round(get_accelerator().memory_allocated() / 2**30, 2):0.2f} GB",
+            f"Max_MA {round(get_accelerator().max_memory_allocated() / 2**30, 2):0.2f} GB",
+            f"NV {round(nv_mem / 2**30, 2):0.2f} GB",
+        ]
+    )
+
+    # get the peak memory to report correct data, so reset the counter for the next call
+    # this will lead to wrong peak reports if `see_mem_usage` is also used during the run,
+    # as it resets the peak counter and there is only one counter
+    get_accelerator().reset_peak_memory_stats()
+
+    return summary

--- a/arctic_training/metrics.py
+++ b/arctic_training/metrics.py
@@ -23,6 +23,7 @@ from typing import cast
 import torch
 from deepspeed.utils.timer import SynchronizedWallClockTimer
 
+from arctic_training.debug import get_mem_metrics
 from arctic_training.utils import human_format_base10_number
 from arctic_training.utils import human_format_secs
 
@@ -169,6 +170,11 @@ class Metrics:
         if "step_tflops" in self.summary_dict:
             summary_str += f" | step tflops: {self.summary_dict['step_tflops']:.1f}"
         summary_str += f" | epoch: {self.summary_dict['epoch']}"
+
+        if self.trainer.global_rank == 0:
+            # XXX: make configurable via yaml
+            mem_metrics = get_mem_metrics()
+            summary_str += f" | {mem_metrics}"
 
         if self.trainer.global_rank == 0:
             print(summary_str)


### PR DESCRIPTION
@sfc-gh-mwyatt, should we make this configurable?

Perhaps:
```
train_log_metrics_mem_stats: true
```
This version isn't costly performance wise, so I didn't add "debug_" to the naming - should be perfectly fine for production use - so in retrospect, perhaps we should just always log it and not have it configurable?

