### PR TITLE
Fix for license check hook adding multiple license

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
         name: check-license
         entry: python ./scripts/check_license.py
         language: python
+        require_serial: true
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:


### PR DESCRIPTION
By default pre-commit runs the pre-commit hooks on multiple parallel processes (https://pre-commit.com/#hooks-require_serial). Setting `require_serial` to true for our license check hook to prevent the adding of the license text multiple times to newly added files.