### PR TITLE
Early catch config errors

### DIFF
--- a/arctic_training/cli.py
+++ b/arctic_training/cli.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 
 def main():
+    from arctic_training.config.trainer import get_config
+
     parser = argparse.ArgumentParser(
         prog="arctic_training",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -44,6 +46,9 @@ def main():
 
     if not args.config.exists():
         raise FileNotFoundError(f"Config file {args.config} not found.")
+
+    # Early catch any config errors
+    _ = get_config(args.config)
 
     exe_path = shutil.which("arctic_training_run")
 


### PR DESCRIPTION
Addresses #158 

If we make a mistake in our yaml config like below, we now catch this error before launching all processes. This gives faster feedback on config problems:

Bad config yaml:
<pre>
type: sft
micro_batch_size: 36

model:
<b>type: "liger" # Accidental dedent</b>
  name_or_path: Felladrin/Llama-160M-Chat-v1
  attn_implementation: sdpa

data:
  sources:
    - HuggingFaceH4/ultrachat_200k:train
  max_length: 1024
</pre>

Error:
```
yaml.parser.ParserError: while parsing a block mapping
  in "repro.yaml", line 1, column 1
expected <block end>, but found '<block mapping start>'
  in "repro.yaml", line 6, column 3
```