### PR TITLE
Human-friendly number parsing

### DIFF
--- a/arctic_training/config/checkpoint.py
+++ b/arctic_training/config/checkpoint.py
@@ -20,6 +20,7 @@ from typing import Type
 from pydantic import Field
 
 from arctic_training.config.base import BaseConfig
+from arctic_training.config.utils import HumanInt
 from arctic_training.registry import get_registered_checkpoint_engine
 
 if TYPE_CHECKING:
@@ -39,10 +40,10 @@ class CheckpointConfig(BaseConfig):
     auto_resume: bool = False
     """ If a checkpoint is found in the output directory, resume training from that checkpoint. """
 
-    save_every_n_steps: int = Field(default=0, ge=0)
+    save_every_n_steps: HumanInt = Field(default=0, ge=0)
     """ How often to trigger a checkpoint save by training global step count. """
 
-    save_every_n_epochs: int = Field(default=0, ge=0)
+    save_every_n_epochs: HumanInt = Field(default=0, ge=0)
     """ How often to trigger a checkpoint save by training epoch count. """
 
     save_end_of_training: bool = False

--- a/arctic_training/config/optimizer.py
+++ b/arctic_training/config/optimizer.py
@@ -20,25 +20,24 @@ from typing import Type
 from pydantic import Field
 
 from arctic_training.config.base import BaseConfig
+from arctic_training.config.utils import HumanFloat
+from arctic_training.registry import get_registered_optimizer_factory
 
 if TYPE_CHECKING:
     from arctic_training.optimizer.factory import OptimizerFactory
-
-
-from arctic_training.registry import get_registered_optimizer_factory
 
 
 class OptimizerConfig(BaseConfig):
     type: str = ""
     """ Optimizer factory type. Defaults to the `optimizer_factory_type` of the trainer. """
 
-    weight_decay: float = Field(default=0.1, ge=0.0)
+    weight_decay: HumanFloat = Field(default=0.1, ge=0.0)
     """ Coefficient for L2 regularization applied to the optimizer's weights. """
 
     betas: Tuple[float, float] = (0.9, 0.999)
     """ Tuple of coefficients used for computing running averages of gradient and its square (e.g., (beta1, beta2) for Adam). """
 
-    learning_rate: float = Field(default=5e-4, ge=0.0, alias="lr")
+    learning_rate: HumanFloat = Field(default=5e-4, ge=0.0, alias="lr")
     """ The initial learning rate. """
 
     @property

--- a/arctic_training/config/trainer.py
+++ b/arctic_training/config/trainer.py
@@ -44,6 +44,7 @@ from arctic_training.config.model import ModelConfig
 from arctic_training.config.optimizer import OptimizerConfig
 from arctic_training.config.scheduler import SchedulerConfig
 from arctic_training.config.tokenizer import TokenizerConfig
+from arctic_training.config.utils import HumanInt
 from arctic_training.config.utils import UniqueKeyLoader
 from arctic_training.config.wandb import WandBConfig
 from arctic_training.registry import _get_class_attr_type_hints
@@ -101,7 +102,7 @@ class TrainerConfig(BaseConfig):
     epochs: int = Field(default=1, ge=0)
     """ Number of epochs to train. """
 
-    loss_log_interval: int = Field(default=1, ge=0)
+    loss_log_interval: HumanInt = Field(default=1, ge=0)
     """ Number of steps between logging loss. """
 
     train_log_iter_interval: Literal[0, 1] = 1
@@ -119,7 +120,7 @@ class TrainerConfig(BaseConfig):
     checkpoint: List[CheckpointConfig] = []
     """ Checkpoint configurations. Multiple checkpoint engines may be used together. """
 
-    train_iters: int = Field(default=0, ge=0)
+    train_iters: HumanInt = Field(default=0, ge=0)
     """ Maximum number of training iterations. """
 
     eval_frequency: int = Field(default=0, ge=0)
@@ -127,7 +128,7 @@ class TrainerConfig(BaseConfig):
     exit_iteration: int = Field(default=0, ge=0)
     """ Force exit of training after specified iteration count (useful for debugging). """
 
-    min_iterations: int = Field(default=0, ge=0)
+    min_iterations: HumanInt = Field(default=0, ge=0)
     """ When >0, the training dataset will be replicated until there is enough data to run this many iterations. """
 
     overfit_first_batch: bool = False
@@ -139,7 +140,7 @@ class TrainerConfig(BaseConfig):
     mem_profiler_dir: Path = Field(default_factory=lambda data: data["logger"].output_dir / "mem-prof")
     """ Path to save memory profiling results. Defaults to `logger.output_dir/mem-prof`. """
 
-    mem_profiler_max_entries: int = Field(default=100_000, ge=1)
+    mem_profiler_max_entries: HumanInt = Field(default=100_000, ge=1)
     """ Maximum number of entries to store in the memory profiler. """
 
     @model_validator(mode="after")

--- a/arctic_training/config/utils.py
+++ b/arctic_training/config/utils.py
@@ -14,8 +14,12 @@
 # limitations under the License.
 
 import os
+import re
+from typing import Annotated
+from typing import Union
 
 import yaml
+from pydantic.functional_validators import BeforeValidator
 
 
 def get_local_rank() -> int:
@@ -40,3 +44,37 @@ class UniqueKeyLoader(yaml.SafeLoader):
                 raise ValueError(f"Duplicate '{key}' key found in YAML on line {key_node.start_mark.line + 1}.")
             mapping.add(key)
         return super().construct_mapping(node, deep)
+
+
+def parse_human_val(value: Union[str, int, float]) -> float:
+    if isinstance(value, str):
+        value = value.replace("_", "")
+        value = value.lower().strip()
+
+        # Handle X^Y expressions
+        match_exp = re.match(r"^(-?\d+\.?\d?)\^(-?\d+\.?\d?)$", value)
+        if match_exp:
+            base, exp = map(float, match_exp.groups())
+            sign = -1 if base < 0 else 1
+            return sign * abs(base) ** exp
+
+        # Handle XeY expressions
+        match_exp = re.match(r"^(-?\d+\.?\d?)e(-?\d+\.?\d?)$", value)
+        if match_exp:
+            base, exp = map(float, match_exp.groups())
+            return base * 10**exp
+
+        # Handle suffixes like k, m, b
+        suffixes = {s: 10 ** (i * 3) for i, s in enumerate("kmbt", start=1)}
+        match_suffix = re.match(r"^(-?\d+\.?\d?)([kmbt])$", value)
+        if match_suffix:
+            num, suffix = match_suffix.groups()
+            return float(num) * suffixes[suffix]
+
+    # Fallback to python conversion
+    return float(value)
+
+
+# Note: parse_human_val will return a float, but pydantic will handle the conversion to int if the field is an int
+HumanInt = Annotated[int, BeforeValidator(parse_human_val)]
+HumanFloat = Annotated[float, BeforeValidator(parse_human_val)]

--- a/arctic_training/config/utils.py
+++ b/arctic_training/config/utils.py
@@ -64,9 +64,10 @@ def parse_human_val(value: Union[str, int, float]) -> float:
             base, exp = map(float, match_exp.groups())
             return base * 10**exp
 
-        # Handle suffixes like k, m, b
-        suffixes = {s: 10 ** (i * 3) for i, s in enumerate("kmbt", start=1)}
-        match_suffix = re.match(r"^(-?\d+\.?\d?)([kmbt])$", value)
+        # Handle suffixes like k, m, b (base 10) and ki, mi, gi (base 2)
+        suffixes = {s: 10 ** (i * 3) for i, s in enumerate(("k", "m", "b", "t"), start=1)}
+        suffixes.update({s: 2 ** (i * 10) for i, s in enumerate(("ki", "mi", "gi", "ti"), start=1)})
+        match_suffix = re.match(rf"^(-?\d+\.?\d?)({'|'.join(suffixes.keys())})$", value)
         if match_suffix:
             num, suffix = match_suffix.groups()
             return float(num) * suffixes[suffix]

--- a/arctic_training/config/utils.py
+++ b/arctic_training/config/utils.py
@@ -51,6 +51,10 @@ def parse_human_val(value: Union[str, int, float]) -> float:
         value = value.replace("_", "")
         value = value.lower().strip()
 
+        # Handle percentage values
+        if value.endswith("%"):
+            return float(value[:-1]) / 100
+
         # Handle X^Y expressions
         match_exp = re.match(r"^(-?\d+\.?\d?)\^(-?\d+\.?\d?)$", value)
         if match_exp:

--- a/arctic_training/data/dpo_factory.py
+++ b/arctic_training/data/dpo_factory.py
@@ -26,6 +26,7 @@ from transformers import BatchEncoding
 from transformers import PreTrainedTokenizerBase
 
 from arctic_training.config.data import DataConfig
+from arctic_training.config.utils import HumanInt
 from arctic_training.data.factory import DataFactory
 from arctic_training.data.sft_factory import pad
 from arctic_training.data.utils import DatasetType
@@ -34,10 +35,10 @@ IGNORE_INDEX = -100
 
 
 class DPODataConfig(DataConfig):
-    max_length: int = 8192
+    max_length: HumanInt = 8192
     """ Maximum length of the input sequence. """
 
-    max_prompt_length: int = 4096
+    max_prompt_length: HumanInt = 4096
     """ Maximum prompt length of the input sequence. """
 
     dpo_prompt_truncation_mode: Literal["keep_start", "keep_end"] = "keep_start"

--- a/arctic_training/data/sft_factory.py
+++ b/arctic_training/data/sft_factory.py
@@ -29,6 +29,7 @@ from transformers import PreTrainedTokenizerBase
 from typing_extensions import Self
 
 from arctic_training.config.data import DataConfig
+from arctic_training.config.utils import HumanInt
 from arctic_training.data.factory import DataFactory
 from arctic_training.data.utils import DatasetType
 
@@ -192,10 +193,10 @@ def pack_sft_batch(
 
 
 class SFTDataConfig(DataConfig):
-    max_length: int = 8192
+    max_length: HumanInt = 8192
     """ Maximum length of the input sequence. """
 
-    div_length: int = 256
+    div_length: HumanInt = 256
     """ The number that the length of the sequence should be divisible by. """
 
     mask_inputs: bool = True

--- a/arctic_training/scheduler/hf_factory.py
+++ b/arctic_training/scheduler/hf_factory.py
@@ -19,12 +19,13 @@ from pydantic import Field
 from transformers import get_scheduler
 
 from arctic_training.config.scheduler import SchedulerConfig
+from arctic_training.config.utils import HumanFloat
 from arctic_training.scheduler.factory import SchedulerFactory
 
 
 class HFSchedulerConfig(SchedulerConfig):
     name: str = "linear"
-    warmup_ratio: float = Field(default=0.1, ge=0.0, le=1.0)
+    warmup_ratio: HumanFloat = Field(default=0.1, ge=0.0, le=1.0)
     """ The fraction of total training steps used for linear learning rate warmup. """
 
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -26,3 +26,22 @@ sub-configurations for data, model, etc.
 .. autopydantic_model:: arctic_training.config.tokenizer.TokenizerConfig
 
 .. autopydantic_model:: arctic_training.config.wandb.WandBConfig
+
+Numerical Formatting
+--------------------
+
+When specifying numerical values in the configuration file, you can use
+human-friendly strings to represent very large or very small numbers. The
+following formats are supported:
+
+- ``X%``: This format represents a percentage. For example, ``50%`` is equivalent to ``0.5``.
+- ``XeY``: This format represents a number in scientific notation. For example,
+  ``1e-6`` is equivalent to ``0.000001``.
+- ``X^Y``: This format represents a number raised to a power. For example,
+  ``2^20`` is equivalent to ``1048576``.
+- ``XK``: This format represents a number in thousands (base 10). For example,
+  ``1K`` is equivalent to ``1000``. Similarly you can use ``M`` for millions,
+  ``B`` for billions, and ``T`` for trillions.
+- ``1Ki``: This format represents a number in kibibytes (base 2). For example,
+  ``1Ki`` is equivalent to ``1024``. Similarly you can use ``Mi`` for mebibytes,
+  ``Gi`` for gibibytes, and ``Ti`` for tebibytes.

--- a/tests/config/test_config_custom_types.py
+++ b/tests/config/test_config_custom_types.py
@@ -79,14 +79,7 @@ def test_human_float(value, expected):
     ), f"Failed for input '{neg_value}', expected parsed value: {-expected}"
 
 
-@pytest.mark.parametrize(
-    "value",
-    [
-        "1.5",
-        "1e-3",
-        "1.00001K",
-    ],
-)
+@pytest.mark.parametrize("value", ["1.5", "1e-3", "1.00001K"])
 def test_human_int_invalid(value):
     class TestConfig(BaseConfig):
         val: HumanInt

--- a/tests/config/test_config_custom_types.py
+++ b/tests/config/test_config_custom_types.py
@@ -85,7 +85,7 @@ def test_human_int_invalid(value):
         val: HumanInt
 
     with pytest.raises(Exception):
-        print(f"Value: {TestConfig(val=value).val}")
+        TestConfig(val=value)
 
 
 @pytest.mark.parametrize("value", ["err", "1Ke3", "1^10e2", "1K^2", "1K^2e3"])

--- a/tests/config/test_config_custom_types.py
+++ b/tests/config/test_config_custom_types.py
@@ -1,0 +1,101 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from arctic_training.config.base import BaseConfig
+from arctic_training.config.utils import HumanFloat
+from arctic_training.config.utils import HumanInt
+from arctic_training.config.utils import parse_human_val
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # Regular int
+        ("1_000_000", 1_000_000),
+        # Exponential
+        ("10^6", 1_000_000),
+        ("1e6", 1_000_000),
+        ("1.1e6", 1_100_000),
+        ("10e-1", 1),
+        # Suffixes
+        ("1K", 1_000),
+        ("1.1K", 1_100),
+        ("1M", 1_000_000),
+        ("1B", 1_000_000_000),
+        ("1T", 1_000_000_000_000),
+    ],
+)
+def test_human_int(value, expected):
+    class TestConfig(BaseConfig):
+        val: HumanInt
+
+    assert TestConfig(val=value).val == expected, f"Failed for input '{value}', expected parsed value: {expected}"
+
+    neg_value = f"-{value}"
+    assert (
+        TestConfig(val=neg_value).val == -expected
+    ), f"Failed for input '{neg_value}', expected parsed value: {-expected}"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        # Regular float
+        ("1.5", 1.5),
+        # Exponential
+        ("10.1^3", 10.1**3),
+        ("1e-3", 0.001),
+        ("1.1e-3", 0.0011),
+        # Suffixes
+        ("1K", 1_000.0),
+        ("1M", 1_000_000.0),
+        ("1B", 1_000_000_000.0),
+        ("1T", 1_000_000_000_000.0),
+    ],
+)
+def test_human_float(value, expected):
+    class TestConfig(BaseConfig):
+        val: HumanFloat
+
+    assert TestConfig(val=value).val == expected, f"Failed for input '{value}', expected parsed value: {expected}"
+
+    neg_value = f"-{value}"
+    assert (
+        TestConfig(val=neg_value).val == -expected
+    ), f"Failed for input '{neg_value}', expected parsed value: {-expected}"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "1.5",
+        "1e-3",
+        "1.00001K",
+    ],
+)
+def test_human_int_invalid(value):
+    class TestConfig(BaseConfig):
+        val: HumanInt
+
+    with pytest.raises(Exception):
+        print(f"Value: {TestConfig(val=value).val}")
+
+
+@pytest.mark.parametrize("value", ["err", "1Ke3", "1^10e2", "1K^2", "1K^2e3"])
+def test_human_val_invalid_syntax(value):
+    with pytest.raises(Exception):
+        parse_human_val(value)

--- a/tests/config/test_config_custom_types.py
+++ b/tests/config/test_config_custom_types.py
@@ -34,9 +34,7 @@ from arctic_training.config.utils import parse_human_val
         # Suffixes
         ("1K", 1_000),
         ("1.1K", 1_100),
-        ("1M", 1_000_000),
-        ("1B", 1_000_000_000),
-        ("1T", 1_000_000_000_000),
+        ("1Ki", 2**10),
     ],
 )
 def test_human_int(value, expected):
@@ -62,9 +60,8 @@ def test_human_int(value, expected):
         ("1.1e-3", 0.0011),
         # Suffixes
         ("1K", 1_000.0),
-        ("1M", 1_000_000.0),
-        ("1B", 1_000_000_000.0),
-        ("1T", 1_000_000_000_000.0),
+        ("1.1K", 1_100.0),
+        ("1Ki", 2**10),
     ],
 )
 def test_human_float(value, expected):

--- a/tests/config/test_config_custom_types.py
+++ b/tests/config/test_config_custom_types.py
@@ -54,6 +54,8 @@ def test_human_int(value, expected):
     [
         # Regular float
         ("1.5", 1.5),
+        # Percentage
+        ("1.5%", 0.015),
         # Exponential
         ("10.1^3", 10.1**3),
         ("1e-3", 0.001),
@@ -76,7 +78,7 @@ def test_human_float(value, expected):
     ), f"Failed for input '{neg_value}', expected parsed value: {-expected}"
 
 
-@pytest.mark.parametrize("value", ["1.5", "1e-3", "1.00001K"])
+@pytest.mark.parametrize("value", ["1.5", "10%", "1e-3", "1.00001K"])
 def test_human_int_invalid(value):
     class TestConfig(BaseConfig):
         val: HumanInt


### PR DESCRIPTION
Added `HumanInt` and `HumanFloat` types for the pydantic configs. Allows parsing human-friendly strings to `int` or `float` values. The following formats are supported:
- `1_000` --> `1000`
- `50%` --> `0.5`
- `1e-3` --> `0.001`
- `2^10` --> `1024`
- `4K` --> `4000` (also `M`, `B`, and `T`)
- `4Ki` --> `4096` (also `Mi`, `Gi`, and `Ti`)