### PR TITLE
Move `max_length` to base `DataConfig`

### DIFF
--- a/arctic_training/config/data.py
+++ b/arctic_training/config/data.py
@@ -29,6 +29,7 @@ from pydantic import model_validator
 from typing_extensions import Self
 
 from arctic_training.config.base import BaseConfig
+from arctic_training.config.utils import HumanInt
 from arctic_training.data.utils import is_local_fs
 from arctic_training.exceptions import RegistryError
 from arctic_training.logging import logger
@@ -75,6 +76,9 @@ class DataConfig(BaseConfig):
 
     train_eval_split: Tuple[float, float] = (1.0, 0.0)
     """ How much of the training data to use for evaluation. """
+
+    max_length: HumanInt = 8192
+    """ Maximum length of the input sequence. """
 
     num_proc: int = 16
     """ Number of processes to use for data loading. """

--- a/arctic_training/data/dpo_factory.py
+++ b/arctic_training/data/dpo_factory.py
@@ -35,9 +35,6 @@ IGNORE_INDEX = -100
 
 
 class DPODataConfig(DataConfig):
-    max_length: HumanInt = 8192
-    """ Maximum length of the input sequence. """
-
     max_prompt_length: HumanInt = 4096
     """ Maximum prompt length of the input sequence. """
 

--- a/arctic_training/data/sft_factory.py
+++ b/arctic_training/data/sft_factory.py
@@ -193,9 +193,6 @@ def pack_sft_batch(
 
 
 class SFTDataConfig(DataConfig):
-    max_length: HumanInt = 8192
-    """ Maximum length of the input sequence. """
-
     div_length: HumanInt = 256
     """ The number that the length of the sequence should be divisible by. """
 


### PR DESCRIPTION
`max_length` is a value that is used by all `DataFactory` subclasses. As such, moving the field to the base `DataConfig` class.

resolves #160 
