### PR TITLE
Avoid corrupted data cache

### DIFF
--- a/arctic_training/data/factory.py
+++ b/arctic_training/data/factory.py
@@ -116,7 +116,9 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
                     )
 
                 logger.info(f"Saving dataset to cache path {cache_path.as_posix()}")
-                dataset.save_to_disk(cache_path.as_posix())
+                tmp_cache_path = cache_path.with_suffix(".incomplete")
+                dataset.save_to_disk(tmp_cache_path.as_posix())
+                tmp_cache_path.rename(cache_path)
 
             dist.barrier()  # Wait for the main process to finish its preprocessing + saving to cache
 

--- a/arctic_training/data/source.py
+++ b/arctic_training/data/source.py
@@ -81,7 +81,9 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
                 )
 
         logger.info(f"Saving data source to cache path {self.cache_path.as_posix()}")
-        dataset.save_to_disk(self.cache_path.as_posix())
+        tmp_cache_path = self.cache_path.with_suffix(".incomplete")
+        dataset.save_to_disk(tmp_cache_path.as_posix())
+        tmp_cache_path.rename(self.cache_path)
 
         return dataset
 


### PR DESCRIPTION
Resolves #172 

Write to `{cache_path}.incomplete` and rename after saving all data is complete.