### PR TITLE
Add early exit kill switch

### DIFF
--- a/arctic_training/config/trainer.py
+++ b/arctic_training/config/trainer.py
@@ -143,6 +143,9 @@ class TrainerConfig(BaseConfig):
     mem_profiler_max_entries: HumanInt = Field(default=100_000, ge=1)
     """ Maximum number of entries to store in the memory profiler. """
 
+    kill_switch_path: Path = Path("/tmp/at_kill_switch")
+    """ Path to a file that can be used to trigger a graceful shutdown mid-training (sets early exit to True). """
+
     @model_validator(mode="after")
     def init_dist(self) -> Self:
         get_accelerator().set_device(self.local_rank)

--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -333,6 +333,9 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
                         step=self.model.global_steps,
                     )
 
+            if self.config.kill_switch_path.exists():
+                self.early_stop = True
+
             if self.early_stop:
                 break
         self.metrics.stop_timer("iter")


### PR DESCRIPTION
Allow user to manually set `early_stop=True` during training by creating a file. Defaults to `/tmp/at_kill_switch`, but can be modified with `kill_switch_path` in the trainer config.

Resolves #126 