### PR TITLE
Add data-process mode to CLI

### DIFF
--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -138,7 +138,7 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
         _validate_class_method(cls, "train", ["self"])
         _validate_class_method(cls, "checkpoint", ["self"])
 
-    def __init__(self, config: TrainerConfig) -> None:
+    def __init__(self, config: TrainerConfig, mode: str = "train") -> None:
         logger.info(f"Initializing Trainer with config:\n{debug.format(config)}")
         self.config = config
         self.epoch_idx = 0
@@ -162,6 +162,9 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
 
         data_factory = self.config.data.factory(self)
         self.train_dataloader, self.eval_dataloader_map = data_factory()
+        if mode == "process-data":
+            return
+
         if self.config.overfit_first_batch:
             self.train_dataloader = OverfitOneBatchDataLoader(self.train_dataloader)
 


### PR DESCRIPTION
Maintains current CLI of `arctic_training config.yaml` but enables a new mode to do all data processing and then early-exit from trainer initialization. This can be used to process and cache data ahead of training runs.

Behavior:
- `arctic_training config.yaml` --> runs training
- `arctic_training train config.yaml` --> runs training
- `arctic_training process-data config.yaml` --> runs data processing, caches data, early exits

@sfc-gh-sbekman 