### PR TITLE
Fix for python wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 
+requires-python = ">= 3.8"
+
 # Dependencies for the project
 dependencies = [
     "datasets",


### PR DESCRIPTION
wheels were being built with `py2-py3` label, but this was incorrect.