### PR TITLE
enabled python -m arctic_training_cli

### DIFF
--- a/arctic_training/model/liger_factory.py
+++ b/arctic_training/model/liger_factory.py
@@ -31,16 +31,21 @@ class LigerModelFactory(HFModelFactory):
             raise ImportError(
                 "You need to install the liger-kernel package to use LigerKernel models: `pip install liger-kernel`"
             )
-        liger_version_min = "0.5.5"  # earlier versions were silently dropping the attn_implementation kwargs
+        liger_version_min = "0.5.9"  # shift_labels support
         liger_version_have = importlib.metadata.version("liger_kernel")
         if version.parse(liger_version_have) < version.parse(liger_version_min):
             raise ValueError(
                 f"liger-kernel>={liger_version_min} is required, but you have liger-kernel=={liger_version_have}"
             )
 
+        # Disable liger's mlp override if we are using our mlp override
+        swiglu = False if self.trainer.config.tiled_mlp_compute else True
+        # XXX: it might be possible to combine the 2 in the future to benefit from the efficient liger swiglu kernel, but currently liger monkey patches the MLP class and thus we would have a race condition on who gets the override.
+
         return AutoLigerKernelForCausalLM.from_pretrained(
             self.config.name_or_path,
             config=model_config,
             attn_implementation=self.config.attn_implementation,
             torch_dtype=self.config.dtype.value,
+            swiglu=swiglu,
         )

--- a/arctic_training/model/liger_factory.py
+++ b/arctic_training/model/liger_factory.py
@@ -31,21 +31,16 @@ class LigerModelFactory(HFModelFactory):
             raise ImportError(
                 "You need to install the liger-kernel package to use LigerKernel models: `pip install liger-kernel`"
             )
-        liger_version_min = "0.5.9"  # shift_labels support
+        liger_version_min = "0.5.5"  # earlier versions were silently dropping the attn_implementation kwargs
         liger_version_have = importlib.metadata.version("liger_kernel")
         if version.parse(liger_version_have) < version.parse(liger_version_min):
             raise ValueError(
                 f"liger-kernel>={liger_version_min} is required, but you have liger-kernel=={liger_version_have}"
             )
 
-        # Disable liger's mlp override if we are using our mlp override
-        swiglu = False if self.trainer.config.tiled_mlp_compute else True
-        # XXX: it might be possible to combine the 2 in the future to benefit from the efficient liger swiglu kernel, but currently liger monkey patches the MLP class and thus we would have a race condition on who gets the override.
-
         return AutoLigerKernelForCausalLM.from_pretrained(
             self.config.name_or_path,
             config=model_config,
             attn_implementation=self.config.attn_implementation,
             torch_dtype=self.config.dtype.value,
-            swiglu=swiglu,
         )

--- a/arctic_training_cli.py
+++ b/arctic_training_cli.py
@@ -66,3 +66,7 @@ def main():
             str(args.config),
         ]
     )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
make possible to run w/o the executable launcher

```
python -m arctic_training_cli x.yml
```
@sfc-gh-mwyatt
