### PR TITLE
fix lr scheduler for sequence parallel

### DIFF
--- a/arctic_training/scheduler/hf_factory.py
+++ b/arctic_training/scheduler/hf_factory.py
@@ -38,6 +38,6 @@ class HFSchedulerFactory(SchedulerFactory):
         return get_scheduler(
             name=self.config.name,
             optimizer=optimizer,
-            num_warmup_steps=num_warmup_steps,
-            num_training_steps=self.trainer.training_horizon,
+            num_warmup_steps=num_warmup_steps * self.trainer.config.sequence_parallel_size,
+            num_training_steps=self.trainer.training_horizon * self.trainer.config.sequence_parallel_size,
         )


### PR DESCRIPTION
Currently using Nx sequence parallel the lr scheduler will advance Nx too fast, hitting lr=0 after 1/N of the training. This PR fixes that.