### PR TITLE
allow loading different supported `datasets` types

### DIFF
--- a/arctic_training/data/hf_source.py
+++ b/arctic_training/data/hf_source.py
@@ -47,7 +47,7 @@ class HFDataSource(DataSource):
 
     def load(self, config: HFDataSourceConfig, split: str) -> DatasetType:
         # Support loading local datasets
-        if config.name_or_path.exists():
+        if config.name_or_path.exists() or "data_files" in config.kwargs:
             dataset = load_from_disk(config.name_or_path.as_posix(), **config.kwargs)
             if isinstance(dataset, DatasetDict):
                 dataset = dataset[split]


### PR DESCRIPTION
`datasets` allows loading `csv`, `json`, etc. via `load_from_disk`. In order to support this in our `HFDataSource` class, adding a check for if `data_files` is defined in the `config.kwargs`. This is required when loading these formats via `load_from_disk` and so it aligns with the `datasets` API.

Example:
```yaml
sources:
  - type: huggingface
    name_or_path: csv
    kwargs:
      data_files: /path/to/data.csv
```