### PR TITLE
Fix custom code import error

### DIFF
--- a/arctic_training/config/trainer.py
+++ b/arctic_training/config/trainer.py
@@ -417,7 +417,6 @@ def load_user_module_from_path(script_path: Path) -> None:
     symlink_path = shared_tmp_dir / f"{unique_module_name}.py"
     try:
         symlink_path.symlink_to(script_path)
-        print(f"CREATED symlink for user script: {symlink_path}")
     except FileExistsError:
         # Another proc created the symlink first, use that one
         pass


### PR DESCRIPTION
When using multiple workers on the torch `DataLoader` object, if a user has custom data classes defined in their projects `train.py`, we would get an import error like `ModuleNotFoundError: No module named 'custom_trainer'` from the spawned child processes.

Fixing that by making sure that the custom user objects are importable to child processes. This is achieved by creating a temporary directory in `/tmp/` and then creating a symlink to the users custom objects script (e.g., `/tmp/user_trainer_symlinks/user_train_828a1303.py` --> `./train.py`). This unique name is to avoid any potential conflicts with other modules.