### PR TITLE
Generalize support for instruct datasets

### DIFF
--- a/arctic_training/__init__.py
+++ b/arctic_training/__init__.py
@@ -32,8 +32,8 @@ from arctic_training.config.trainer import TrainerConfig
 from arctic_training.config.trainer import get_config
 from arctic_training.data.dpo_factory import DPODataFactory
 from arctic_training.data.factory import DataFactory
-from arctic_training.data.hf_source import HFDataSource
 from arctic_training.data.hf_instruct_source import HFInstructDataSource
+from arctic_training.data.hf_source import HFDataSource
 from arctic_training.data.sft_factory import SFTDataFactory
 from arctic_training.data.source import DataSource
 from arctic_training.logging import logger

--- a/arctic_training/__init__.py
+++ b/arctic_training/__init__.py
@@ -33,6 +33,7 @@ from arctic_training.config.trainer import get_config
 from arctic_training.data.dpo_factory import DPODataFactory
 from arctic_training.data.factory import DataFactory
 from arctic_training.data.hf_source import HFDataSource
+from arctic_training.data.hf_instruct_source import HFInstructDataSource
 from arctic_training.data.sft_factory import SFTDataFactory
 from arctic_training.data.source import DataSource
 from arctic_training.logging import logger

--- a/arctic_training/data/hf_instruct_source.py
+++ b/arctic_training/data/hf_instruct_source.py
@@ -27,8 +27,8 @@ from arctic_training.data.hf_source import HFDataSourceConfig
 from arctic_training.data.utils import DatasetType
 
 
-class HFInstructDataSourceConfig(HFDataSourceConfig):
-    role_mapping: Dict[str, str] = Field(default_factory=lambda: {"user": "question", "assistant": "response"})
+class HFDataSourceConfigInstruct(HFDataSourceConfig):
+    role_mapping: Dict[str, str] = Field(default_factory=lambda: {"user": "user", "assistant": "assistant"})
     """
     Flexible mapping from message roles to data extraction paths. Supports:
     - Simple field: {"user": "question", "assistant": "response"}
@@ -60,7 +60,7 @@ class HFInstructDataSource(HFDataSource):
     """Base DataSource class for instruction-following datasets used in SFT."""
 
     name = "huggingface_instruct"
-    config: HFInstructDataSourceConfig
+    config: HFDataSourceConfigInstruct
 
     def post_load_callback(self, dataset: DatasetType) -> DatasetType:
         def process_example(example: Dict[str, Any]) -> Dict[str, Any]:

--- a/arctic_training/data/hf_instruct_source.py
+++ b/arctic_training/data/hf_instruct_source.py
@@ -1,0 +1,99 @@
+# Copyright 2025 Snowflake Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict
+
+from arctic_training.data.hf_source import HFDataSource
+from arctic_training.data.hf_source import HFDataSourceConfig
+from arctic_training.data.utils import DatasetType
+
+
+class HFInstructDataSourceConfig(HFDataSourceConfig):
+    role_mapping: Dict[str, str] = {"user": "user", "assistant": "assistant"}
+    """
+    Map dataset columns to message roles OR map role field values to standard roles.
+    For column mapping: {"question": "user", "response": "assistant"}
+    For role value mapping: {"human": "user", "ai": "assistant"}
+    """
+
+    conversation_column: str = "messages"
+    """Column name containing pre-formatted conversation arrays."""
+
+    role_field: str = "role"
+    """Field name for role in conversation dicts."""
+
+    content_field: str = "content"
+    """Field name for content in conversation dicts."""
+
+
+class HFInstructDataSource(HFDataSource):
+    """Base DataSource class for instruction-following datasets used in SFT."""
+
+    name = "huggingface_instruct"
+    config: HFInstructDataSourceConfig
+
+    def post_load_callback(self, dataset: DatasetType) -> DatasetType:
+        if self.config.conversation_column in dataset.column_names:
+            dataset = self._format_conversation_column(dataset)
+        elif all(col in dataset.column_names for col in self.config.role_mapping.keys()):
+            dataset = self._format_role_mapping(dataset)
+        else:
+            raise ValueError(
+                "Dataset does not contain expected columns. "
+                f"Available columns: {sorted(dataset.column_names)}. "
+                f"Expected either conversation column '{self.config.conversation_column}' "
+                f"or role mapping columns: {sorted(self.config.role_mapping.keys())}."
+            )
+
+        return dataset
+
+    def _format_conversation_column(self, dataset: DatasetType) -> DatasetType:
+        """Format dataset when using a pre-existing conversation column."""
+
+        def process_example(example):
+            conversation = example[self.config.conversation_column]
+            messages = []
+
+            for item in conversation:
+                role = item.get(self.config.role_field)
+                content = item.get(self.config.content_field)
+                if role in self.config.role_mapping:
+                    role = self.config.role_mapping[role]
+                messages.append({"role": role, "content": content})
+
+            return {"messages": messages}
+
+        return dataset.map(
+            process_example,
+            num_proc=self.data_factory.config.num_proc,
+            desc=f"Loading {self.name}",
+        )
+
+    def _format_role_mapping(self, dataset: DatasetType) -> DatasetType:
+        """Format dataset when using role mapping."""
+
+        def process_example(example):
+            messages = []
+
+            for column, role in self.config.role_mapping.items():
+                messages.append({"role": role, "content": example[column]})
+
+            return {"messages": messages}
+
+        return dataset.map(
+            process_example,
+            num_proc=self.data_factory.config.num_proc,
+            desc=f"Loading {self.name}",
+        )

--- a/arctic_training/data/hf_instruct_source.py
+++ b/arctic_training/data/hf_instruct_source.py
@@ -20,7 +20,7 @@ from typing import Optional
 from typing import Union
 
 from pydantic import Field
-from pydantic import validator
+from pydantic import field_validator
 
 from arctic_training.data.hf_source import HFDataSource
 from arctic_training.data.hf_source import HFDataSourceConfig
@@ -36,8 +36,9 @@ class HFInstructDataSourceConfig(HFDataSourceConfig):
     - Conversation filter with field: {"user": "conversations.from.human,value", "assistant": "conversations.from.agent,value"}
     """
 
-    @validator("role_mapping")
-    def validate_role_mapping(cls, v):
+    @field_validator("role_mapping", mode="before")
+    @classmethod
+    def validate_role_mapping(cls, v: Dict[str, str]) -> Dict[str, str]:
         """Simple validation for role_mapping paths."""
         for role, path_spec in v.items():
             if "," in path_spec:

--- a/arctic_training/data/hf_instruct_source.py
+++ b/arctic_training/data/hf_instruct_source.py
@@ -15,13 +15,15 @@
 
 from typing import Dict
 
+from pydantic import Field
+
 from arctic_training.data.hf_source import HFDataSource
 from arctic_training.data.hf_source import HFDataSourceConfig
 from arctic_training.data.utils import DatasetType
 
 
 class HFInstructDataSourceConfig(HFDataSourceConfig):
-    role_mapping: Dict[str, str] = {"user": "user", "assistant": "assistant"}
+    role_mapping: Dict[str, str] = Field(default_factory=lambda: {"user": "user", "assistant": "assistant"})
     """
     Map dataset columns to message roles OR map role field values to standard roles.
     For column mapping: {"question": "user", "response": "assistant"}

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,10 @@
 # Minimal makefile for Sphinx documentation
 #
 
+#
+# first install the dependencies
+# cd .. && python scripts/install_deps.py docs && cd -
+
 # You can set these variables from the command line, and also
 # from the environment for the first two.
 SPHINXOPTS    ?=

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -263,7 +263,7 @@ Config:
 
 .. code:: python
 
-   {"conversations": [{"sender": "human", "message": "Hello world"}, {"sender": "system", "message": "Hi there"}]}
+   {"conversations": [{"sender": "system", "message": "Hello world"}, {"sender": "user, "message": "Hi there"}]}
 
 Config:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -263,7 +263,7 @@ Config:
 
 .. code:: python
 
-   {"conversations": [{"from": "human", "value": "Hello world"}, {"from": "agent", "value": "Hi there"}]}
+   {"conversations": [{"sender": "human", "message": "Hello world"}, {"sender": "system", "message": "Hi there"}]}
 
 Config:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -155,3 +155,131 @@ API:
         config = get_config(config_dict)
         trainer = CustomTrainer(config)
         trainer.train()
+
+
+Datasets
+----------
+
+How to use a dataset of your choice. Since there is no standard to how each dataset is defined it's not always easy to write a generic API that will work with any dataset.
+
+SFT Datasets
+============
+
+While one could write a class for any new dataset, we have designed a flexible dataset type that should allow to remap many existing Instruct/SFT datasets to this dataset type:
+
+The ``role_mapping`` dict indicates how to locate the role and content
+within the dataset structure. We accept two types of inputs:
+
+1. ``{role_name} : {column_name}``
+
+2. ``{role_name} : {column_name.filter_field.filter_value}``
+
+Additionally ``content_field`` can be used when a deep structure with
+complex columns is used and the value name needs remapping, see example
+5 below for such a use-case.
+
+Examples:
+
+1. Dataset structure:
+
+.. code:: python
+
+   {"user": "What is the capital of France?", "assistant": "The capital of France is Paris."}
+
+Config:
+
+.. code:: yaml
+
+   data:
+     sources:
+       - type: huggingface_instruct
+         name_or_path:  Josephgflowers/Finance-Instruct-500k
+         split: train
+
+See https://huggingface.co/datasets/Josephgflowers/Finance-Instruct-500k
+
+2. Dataset structure:
+
+.. code:: python
+
+   {"question": "What is the capital of France?", "response": "The capital of France is Paris."}
+
+Config:
+
+.. code:: yaml
+
+   data:
+     sources:
+       - type: huggingface_instruct
+         name_or_path: HuggingFaceH4/helpful-instructions
+         split: train
+         sample_count: 1000
+         role_mapping:
+           user: instruction
+           assistant: demonstration
+
+See https://huggingface.co/datasets/HuggingFaceH4/helpful-instructions
+
+3. Dataset structure:
+
+.. code:: python
+
+   {"messages": [{"role": "user", "content": "Hello world"}, {"role": "assistant", "content": "Hi there"}]}
+
+Config:
+
+.. code:: yaml
+
+   data:
+     sources:
+       - type: huggingface_instruct
+         name_or_path: HuggingFaceH4/ultrachat_200k
+         split: train_sft
+         role_mapping:
+           user: messages.role.user
+           assistant: messages.role.assistant
+
+See https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k
+
+4. Dataset structure:
+
+.. code:: python
+
+   {"conversations": [{"role": "human", "content": "Hello world"}, {"role": "agent", "content": "Hi there"}]}
+
+Config:
+
+.. code:: yaml
+
+   data:
+     sources:
+       - type: huggingface_instruct
+         name_or_path: /path/to/data
+         role_mapping:
+           user: conversations.role.human
+           assistant: conversations.role.agent
+
+5. Dataset structure:
+
+.. code:: python
+
+   {"conversations": [{"from": "human", "value": "Hello world"}, {"from": "agent", "value": "Hi there"}]}
+
+Config:
+
+.. code:: yaml
+
+   data:
+     sources:
+       - type: huggingface_instruct
+         name_or_path: recursal/Europarl-Translation-Instruct
+         split: full
+         sample_count: 1000
+         role_mapping:
+           user: conversations.sender.system
+           assistant: conversations.sender.user
+           content_key: message
+
+https://huggingface.co/datasets/recursal/Europarl-Translation-Instruct
+additionally has the user/assistant roles reversed, so we can easily fix
+it in our remapping.

--- a/projects/sequence-parallelism/README.md
+++ b/projects/sequence-parallelism/README.md
@@ -33,8 +33,7 @@ cd projects/sequence-parallelism
 To launch a 1-GPU job:
 ```
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
-export CUDA_VISIBLE_DEVICES=0
-arctic_training run-sp1-llama-8b.yml
+arctic_training run-sp1-llama-8b.yml --num_gpus 0
 ```
 
 You have 2 examples for 1 gpu:
@@ -47,7 +46,6 @@ You have 2 examples for 1 gpu:
 To launch an 8-GPU job:
 ```
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
-export CUDA_VISIBLE_DEVICES=0
 arctic_training run-sp8-llama-8b.yml
 ```
 

--- a/projects/sequence-parallelism/README.md
+++ b/projects/sequence-parallelism/README.md
@@ -116,12 +116,17 @@ You have multiple examples for 2+ node jobs:
 
 ### Modifying the dataset
 
-If you want to use your own database, edit this section of the desired `yaml` file and replace it with the dataset of your choice.
+If you want to use your own instruct type of dataset instead of [HuggingFaceH4/ultrachat_200k](https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k), edit this section of the desired `yaml` recipe file and replace it with the dataset of your choice, while remapping the column and role names and the dataset split name if needed. You will find multiple supported dataset types and examples [here](https://arctictraining.readthedocs.io/en/latest/usage.html#sft-datasets).
 
 ```
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
 ```
 
 ### Environment used to create these examples

--- a/projects/sequence-parallelism/run-sp1-llama-8b-baseline.yml
+++ b/projects/sequence-parallelism/run-sp1-llama-8b-baseline.yml
@@ -28,7 +28,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
   cache_dir: data-cache
   dl_num_workers: 1
 

--- a/projects/sequence-parallelism/run-sp1-llama-8b-baseline.yml
+++ b/projects/sequence-parallelism/run-sp1-llama-8b-baseline.yml
@@ -28,8 +28,7 @@ model:
 
 data:
   sources:
-    #- HuggingFaceH4/ultrachat_200k
-    - HuggingFaceH4/ultrachat_200k:train[:10000]
+    - HuggingFaceH4/ultrachat_200k
   cache_dir: data-cache
   dl_num_workers: 1
 

--- a/projects/sequence-parallelism/run-sp1-llama-8b.yml
+++ b/projects/sequence-parallelism/run-sp1-llama-8b.yml
@@ -29,7 +29,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp1-llama-8b.yml
+++ b/projects/sequence-parallelism/run-sp1-llama-8b.yml
@@ -30,7 +30,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-    #- HuggingFaceH4/ultrachat_200k:train[:10000]
+
   cache_dir: data-cache
   dl_num_workers: 1
 

--- a/projects/sequence-parallelism/run-sp1-qwen3-32b.yml
+++ b/projects/sequence-parallelism/run-sp1-qwen3-32b.yml
@@ -34,7 +34,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-    #- HuggingFaceH4/ultrachat_200k:train[:10000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp1-qwen3-32b.yml
+++ b/projects/sequence-parallelism/run-sp1-qwen3-32b.yml
@@ -33,7 +33,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp16-llama-70b.yml
+++ b/projects/sequence-parallelism/run-sp16-llama-70b.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-  #  - HuggingFaceH4/ultrachat_200k:train[:5000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp16-llama-70b.yml
+++ b/projects/sequence-parallelism/run-sp16-llama-70b.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp16-llama-8b.yml
+++ b/projects/sequence-parallelism/run-sp16-llama-8b.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-  #  - HuggingFaceH4/ultrachat_200k:train[:5000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp16-llama-8b.yml
+++ b/projects/sequence-parallelism/run-sp16-llama-8b.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp16-qwen3-32b.yml
+++ b/projects/sequence-parallelism/run-sp16-qwen3-32b.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-  #  - HuggingFaceH4/ultrachat_200k:train[:5000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp16-qwen3-32b.yml
+++ b/projects/sequence-parallelism/run-sp16-qwen3-32b.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp32-llama-70b.yml
+++ b/projects/sequence-parallelism/run-sp32-llama-70b.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-  #  - HuggingFaceH4/ultrachat_200k:train[:5000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp32-llama-70b.yml
+++ b/projects/sequence-parallelism/run-sp32-llama-70b.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp32-llama-8b-baseline.yml
+++ b/projects/sequence-parallelism/run-sp32-llama-8b-baseline.yml
@@ -27,8 +27,7 @@ model:
 
 data:
   sources:
-  #  - HuggingFaceH4/ultrachat_200k
-    - HuggingFaceH4/ultrachat_200k:train[:25000]
+    - HuggingFaceH4/ultrachat_200k
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp32-llama-8b-baseline.yml
+++ b/projects/sequence-parallelism/run-sp32-llama-8b-baseline.yml
@@ -27,7 +27,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp32-llama-8b.yml
+++ b/projects/sequence-parallelism/run-sp32-llama-8b.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-  #  - HuggingFaceH4/ultrachat_200k:train[:5000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp32-llama-8b.yml
+++ b/projects/sequence-parallelism/run-sp32-llama-8b.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp32-qwen3-32b.yml
+++ b/projects/sequence-parallelism/run-sp32-qwen3-32b.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-  #  - HuggingFaceH4/ultrachat_200k:train[:5000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp32-qwen3-32b.yml
+++ b/projects/sequence-parallelism/run-sp32-qwen3-32b.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp64-llama-70b.yml
+++ b/projects/sequence-parallelism/run-sp64-llama-70b.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-  #  - HuggingFaceH4/ultrachat_200k:train[:5000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp64-llama-70b.yml
+++ b/projects/sequence-parallelism/run-sp64-llama-70b.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp64-qwen3-32b.yml
+++ b/projects/sequence-parallelism/run-sp64-qwen3-32b.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp64-qwen3-32b.yml
+++ b/projects/sequence-parallelism/run-sp64-qwen3-32b.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-  #  - HuggingFaceH4/ultrachat_200k:train[:5000]
+
   cache_dir: data-cache
   dl_num_workers: 1
 

--- a/projects/sequence-parallelism/run-sp8-llama-70b.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-70b.yml
@@ -27,8 +27,7 @@ model:
 
 data:
   sources:
-    #- HuggingFaceH4/ultrachat_200k
-    - HuggingFaceH4/ultrachat_200k:train[:10000]
+    - HuggingFaceH4/ultrachat_200k
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp8-llama-70b.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-70b.yml
@@ -27,7 +27,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp8-llama-8b-no-mlp-no-act-offload.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b-no-mlp-no-act-offload.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp8-llama-8b-no-mlp-no-act-offload.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b-no-mlp-no-act-offload.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-    #- HuggingFaceH4/ultrachat_200k:train[:10000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp8-llama-8b-no-ulysses-no-liger-no-extras.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b-no-ulysses-no-liger-no-extras.yml
@@ -25,7 +25,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp8-llama-8b-no-ulysses-no-liger-no-extras.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b-no-ulysses-no-liger-no-extras.yml
@@ -26,7 +26,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-    #- HuggingFaceH4/ultrachat_200k:train[:10000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp8-llama-8b-no-ulysses-yes-liger-no-extras.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b-no-ulysses-yes-liger-no-extras.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp8-llama-8b-no-ulysses-yes-liger-no-extras.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b-no-ulysses-yes-liger-no-extras.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-    #- HuggingFaceH4/ultrachat_200k:train[:10000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp8-llama-8b-yes-act-offload.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b-yes-act-offload.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp8-llama-8b-yes-act-offload.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b-yes-act-offload.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-    #- HuggingFaceH4/ultrachat_200k:train[:10000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp8-llama-8b-yes-mlp.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b-yes-mlp.yml
@@ -25,7 +25,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp8-llama-8b-yes-mlp.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b-yes-mlp.yml
@@ -26,7 +26,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-    #- HuggingFaceH4/ultrachat_200k:train[:10000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp8-llama-8b.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 

--- a/projects/sequence-parallelism/run-sp8-llama-8b.yml
+++ b/projects/sequence-parallelism/run-sp8-llama-8b.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-    #- HuggingFaceH4/ultrachat_200k:train[:10000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp8-qwen3-32b.yml
+++ b/projects/sequence-parallelism/run-sp8-qwen3-32b.yml
@@ -27,7 +27,7 @@ model:
 data:
   sources:
     - HuggingFaceH4/ultrachat_200k
-  #  - HuggingFaceH4/ultrachat_200k:train[:5000]
+
   cache_dir: data-cache
 
   dl_num_workers: 1

--- a/projects/sequence-parallelism/run-sp8-qwen3-32b.yml
+++ b/projects/sequence-parallelism/run-sp8-qwen3-32b.yml
@@ -26,7 +26,13 @@ model:
 
 data:
   sources:
-    - HuggingFaceH4/ultrachat_200k
+    - type: huggingface_instruct
+      name_or_path: HuggingFaceH4/ultrachat_200k
+      split: train_sft
+      role_mapping:
+        user: messages.role.user
+        assistant: messages.role.assistant
+
 
   cache_dir: data-cache
 


### PR DESCRIPTION
Subclass the `HFDataSource` to `HFInstructDataSource` that supports the most common formats of instruct datasets:
1. Single column containing conversation examples in the form of a list of dicts
2. Multiple columns, each with the content for user, assistant, etc.

The `role_mapping` dict indicates how to locate the role and content within the dataset structure. We accept two types of inputs:
1. `{role_name} : {column_name}`
2. `{role_name} : {column_name.filter_field.filter_value}`

Additionally `content_field` can be used when a deep structure with complex columns is used and the value name needs remapping, see example 5 below for such a use-case.

Examples:


1. Dataset structure:
```python
{"user": "What is the capital of France?", "assistant": "The capital of France is Paris."}
```
Config:
```yaml
data:
  sources:
    - type: huggingface_instruct
      name_or_path:  Josephgflowers/Finance-Instruct-500k
      split: train
```

See https://huggingface.co/datasets/Josephgflowers/Finance-Instruct-500k

2. Dataset structure:
```python
{"question": "What is the capital of France?", "response": "The capital of France is Paris."}
```
Config:
```yaml
data:
  sources:
    - type: huggingface_instruct
      name_or_path: HuggingFaceH4/helpful-instructions
      split: train
      sample_count: 1000
      role_mapping:
        user: instruction
        assistant: demonstration
```

See https://huggingface.co/datasets/HuggingFaceH4/helpful-instructions


3. Dataset structure:
```python
{"messages": [{"role": "user", "content": "Hello world"}, {"role": "assistant", "content": "Hi there"}]}
```
Config:
```yaml
data:
  sources:
    - type: huggingface_instruct
      name_or_path: HuggingFaceH4/ultrachat_200k
      split: train_sft
      role_mapping:
        user: messages.role.user
        assistant: messages.role.assistant
```

See https://huggingface.co/datasets/HuggingFaceH4/ultrachat_200k

4. Dataset structure:
```python
{"conversations": [{"role": "human", "content": "Hello world"}, {"role": "agent", "content": "Hi there"}]}
```
Config:
```yaml
data:
  sources:
    - type: huggingface_instruct
      name_or_path: /path/to/data
      role_mapping:
        user: conversations.role.human
        assistant: conversations.role.agent
```

5. Dataset structure:
```python
{"conversations": [{"from": "human", "value": "Hello world"}, {"from": "agent", "value": "Hi there"}]}
```
Config:
```yaml
data:
  sources:
    - type: huggingface_instruct
      name_or_path: recursal/Europarl-Translation-Instruct
      split: full
      sample_count: 1000
      role_mapping:
        user: conversations.sender.system
        assistant: conversations.sender.user
        content_key: message
```        

https://huggingface.co/datasets/recursal/Europarl-Translation-Instruct additionally has the user/assistant roles reversed, so we can easily fix it in our remapping.