### PR TITLE
[ALST] sync with transformers>=4.53 masking utils changes

### DIFF
--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -209,16 +209,12 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
         model_factory = self.config.model.factory(self)
         self.model = model_factory()
 
-        # XXX: not sure when to enable this temp hack until HF Transformers comes up with a way to
-        # override this properly - apparently there is a plan to do so in the future versions of
-        # transformers.
-        # 1. definitely needed for SP
-        # 2. but it also should benefit a single gpu use case
+        # prevent causal mask from being created in HF Transformers - it's a huge `[bs, seqlen, seqlen]` tensor
+        # XXX: This should also benefit a single gpu use case when SDPA is used - so perhaps remove the SP>1 check?
         if self.config.sequence_parallel_size > 1 and self.config.model.attn_implementation != "flash_attention_2":
-            # prevent from causal mask being created in HF Transformers - it's a huge `[bs, seqlen, seqlen]` tensor
-            model_without_head = self.model_unwrapped.model
-            if hasattr(model_without_head, "_update_causal_mask"):
-                model_without_head._update_causal_mask = lambda *args: None
+            import transformers.masking_utils
+
+            transformers.masking_utils.ALL_MASK_ATTENTION_FUNCTIONS["sdpa"] = lambda *args, **kwargs: None
 
         optimizer_factory = self.config.optimizer.factory(self)
         self.optimizer = optimizer_factory()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dependencies = [
     "tabulate",
     "torch",
     "tqdm",
-    "transformers>=4.51.3", # attention api + qwen
+    "transformers>=4.53", # update_causal_mask
     "wandb",
     "yq",
 ]
@@ -88,6 +88,7 @@ dev = [
 testing = [
     "pytest",
     "pytest-instafail",
+    "parameterized",
 ]
 
 formatting = [


### PR DESCRIPTION
This PR:
1. syncs with transformers>=4.53 masking utils changes
2. updates the tests to also test for sdpa and not just fa2
3. complete the rename from ulysses-plus to ulysses-alst