### PR TITLE
add FA3 support

### DIFF
--- a/arctic_training/config/model.py
+++ b/arctic_training/config/model.py
@@ -80,13 +80,14 @@ class ModelConfig(BaseConfig):
 
     @field_validator("attn_implementation", mode="after")
     def validate_attn_implementation(cls, value: str) -> str:
-        if value == "flash_attention_2":
+        if value in ["flash_attention_2", "flash_attention_3"]:
             try:
                 import flash_attn  # noqa: F401
             except (ImportError, ModuleNotFoundError):
                 raise ValueError(
-                    "flash_attention_2 requires the flash_attn package. Install with"
+                    f"{value} requires the flash_attn package. Install with"
                     " `pip install flash_attn`. Please refer to documentation at"
-                    " https://huggingface.co/docs/transformers/perf_infer_gpu_one#flashattention-2"
+                    " https://huggingface.co/docs/transformers/perf_infer_gpu_one#flashattention-2."
+                    " For FA3 build from the github source"
                 )
         return value

--- a/arctic_training/config/model.py
+++ b/arctic_training/config/model.py
@@ -88,6 +88,7 @@ class ModelConfig(BaseConfig):
                     f"{value} requires the flash_attn package. Install with"
                     " `pip install flash_attn`. Please refer to documentation at"
                     " https://huggingface.co/docs/transformers/perf_infer_gpu_one#flashattention-2."
-                    " For FA3 build from the github source"
+                    " For FA3 build from the github source: git clone https://github.com/Dao-AILab/flash-attention;"
+                    " cd flash-attention/hopper; pip install . --no-build-isolation --no-clean"
                 )
         return value

--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -211,7 +211,10 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
 
         # prevent causal mask from being created in HF Transformers - it's a huge `[bs, seqlen, seqlen]` tensor
         # XXX: This should also benefit a single gpu use case when SDPA is used - so perhaps remove the SP>1 check?
-        if self.config.sequence_parallel_size > 1 and self.config.model.attn_implementation != "flash_attention_2":
+        if self.config.sequence_parallel_size > 1 and self.config.model.attn_implementation not in [
+            "flash_attention_2",
+            "flash_attention_3",
+        ]:
             import transformers.masking_utils
 
             transformers.masking_utils.ALL_MASK_ATTENTION_FUNCTIONS["sdpa"] = lambda *args, **kwargs: None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "tabulate",
     "torch",
     "tqdm",
-    "transformers>=4.53.0", # update_causal_mask
+    "transformers>=4.53.2", # fa3
     "wandb",
     "yq",
 ]


### PR DESCRIPTION
adding FA3 support

If you want to try FA3 you have to build it manually.
```
git clone https://github.com/Dao-AILab/flash-attention
cd flash-attention/hopper
pip install . --no-build-isolation --no-clean
```
then copy the built wheel. 