### PR TITLE
Better datasets map and filter performance

### DIFF
--- a/arctic_training/data/factory.py
+++ b/arctic_training/data/factory.py
@@ -198,6 +198,7 @@ class DataFactory(ABC, CallbackMixin, metaclass=RegistryMeta):
             dataset = data_source()
             datasets.append(dataset)
         dataset = concatenate_datasets(datasets)
+        dataset = dataset.shuffle(seed=self.config.seed)
         return dataset
 
     @callback_wrapper("process")


### PR DESCRIPTION
In the case we load several datasets and some of those datasets have samples that are much larger than other datasets, when we call a `dataset.map` or a `data.filter`, one of the worker processes can get stuck with a disproportionately large amount of work. This leads to the case of all other workers waiting on a single worker to complete. Doing a shuffle after concatenating the datasets avoids this problem and assures that work is evenly distributed across the worker processes.