### PR TITLE
Extract eval log iter condition

### DIFF
--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -316,9 +316,11 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
             self.eval_dataloader,
             desc="Eval Batches",
             unit="batch",
-            disable=self.global_rank != 0
-            or (self.global_step // self.config.eval_interval % self.config.eval_log_iter_interval != 0),
+            disable=self.global_rank != 0 or not self.is_eval_log_iter(),
         )
+
+    def is_eval_log_iter(self) -> bool:
+        return self.global_step // self.config.eval_interval % self.config.eval_log_iter_interval == 0
 
     @cached_property
     def device(self) -> torch.device:
@@ -439,7 +441,7 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
                 if self.config.eval_interval != 0 and self.global_step % self.config.eval_interval == 0:
                     self.evaluate()
 
-                    if not self.eval_batches.disable:
+                    if self.is_eval_log_iter():
                         self.metrics.print_summary(prefix="eval")
 
                         if self.wandb_experiment is not None:


### PR DESCRIPTION
This prevents from recreating a tqdm object twice an evaluation iter.