### PR TITLE
report the correct device in pynvml

### DIFF
--- a/arctic_training/debug.py
+++ b/arctic_training/debug.py
@@ -40,7 +40,8 @@ pynvml_handle = None
 
 def get_device_id():
     """
-    try to identify the device id running this rank with the help of LOCAL_RANK and CUDA_VISIBLE_DEVICES env vars. The device id is needed for applicaitons like pynvml.
+    Derive the device id running this rank with the help of LOCAL_RANK and CUDA_VISIBLE_DEVICES env vars. The device id is
+    needed for applications like pynvml.
     """
 
     if dist.is_initialized():

--- a/arctic_training/debug.py
+++ b/arctic_training/debug.py
@@ -60,7 +60,7 @@ def get_nvml_mem():
         return 0
 
     if pynvml_handle is None:
-        device_id = get_device_id():
+        device_id = get_device_id()
         pynvml_handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
         # pynvml.nvmlShutdown()
     memory_info = pynvml.nvmlDeviceGetMemoryInfo(pynvml_handle)

--- a/arctic_training/debug.py
+++ b/arctic_training/debug.py
@@ -38,8 +38,19 @@ torch_max_memory_reserved = get_accelerator().max_memory_reserved
 pynvml_handle = None
 
 
-def get_local_rank():
-    return int(os.getenv("LOCAL_RANK", 0))
+def get_device_id():
+    """
+    try to identify the device id running this rank with the help of LOCAL_RANK and CUDA_VISIBLE_DEVICES env vars. The device id is needed for applicaitons like pynvml.
+    """
+
+    if dist.is_initialized():
+        local_rank = int(os.getenv("LOCAL_RANK", 0))
+    else:
+        local_rank = 0
+
+    visible_device_ids = list(map(int, os.getenv("CUDA_VISIBLE_DEVICES", "0").split(",")))
+
+    return visible_device_ids[local_rank]
 
 
 def get_nvml_mem():
@@ -49,8 +60,8 @@ def get_nvml_mem():
         return 0
 
     if pynvml_handle is None:
-        rank = get_local_rank() if dist.is_initialized() else 0
-        pynvml_handle = pynvml.nvmlDeviceGetHandleByIndex(rank)
+        device_id = get_device_id():
+        pynvml_handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
         # pynvml.nvmlShutdown()
     memory_info = pynvml.nvmlDeviceGetMemoryInfo(pynvml_handle)
     return memory_info.used

--- a/arctic_training/debug.py
+++ b/arctic_training/debug.py
@@ -46,16 +46,15 @@ def get_device_id():
     returns `None` if CUDA_VISIBLE_DEVICES is set to ""
     """
 
+    cuda_visible_devices = os.getenv("CUDA_VISIBLE_DEVICES", "0")
+    if cuda_visible_devices == "":
+        return None
+    visible_device_ids = list(map(int, cuda_visible_devices.split(",")))
+
     if dist.is_initialized():
         local_rank = int(os.getenv("LOCAL_RANK", 0))
     else:
         local_rank = 0
-
-    cuda_visible_devices = os.getenv("CUDA_VISIBLE_DEVICES", "0")
-    if cuda_visible_devices == "":
-        return None
-
-    visible_device_ids = list(map(int, cuda_visible_devices.split(",")))
 
     return visible_device_ids[local_rank]
 


### PR DESCRIPTION
Currently if I run `CUDA_VISIBLE_DEVICES=2 arctic_training ...` the memory usage in metrics logs is reported for gpu0 and not gpu2, so adding some logic to figure the device id from the env vars.