### PR TITLE
Fix: Make isort see `wandb` as third party

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[settings]
+known_third_party = wandb


### PR DESCRIPTION
In the case we have a local `./wandb/`, isort would incorrectly assume that `import wandb` should be part of local library imports rather than third-party imports.