### PR TITLE
[eval] replace `torch.inference_mode` with `torch.no_grad`

### DIFF
--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -501,6 +501,7 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
         """
         Evaluation loop. Measures the model's performance on the evaluation dataset.
         """
+        self.model.eval()
         with torch.no_grad():
             losses = [self.loss(eval_batch).item() for eval_batch in self.eval_batches]
         self.metrics.record("loss/eval", losses)  # type: ignore

--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -497,15 +497,13 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
                 self.wandb_experiment.finish()
 
     @callback_wrapper("evaluate")
-    @torch.inference_mode()
     def evaluate(self) -> None:
         """
         Evaluation loop. Measures the model's performance on the evaluation dataset.
         """
-        self.model.eval()
-        losses = [self.loss(eval_batch).item() for eval_batch in self.eval_batches]
+        with torch.no_grad():
+            losses = [self.loss(eval_batch).item() for eval_batch in self.eval_batches]
         self.metrics.record("loss/eval", losses)  # type: ignore
-        self.model.train()
 
     @callback_wrapper("checkpoint")
     def checkpoint(self) -> None:


### PR DESCRIPTION
I'm getting:
```
 File "/code/users/stas/github/DeepSpeed/deepspeed/runtime/zero/linear.py", line 116, in zero3_linear_wrap
   return LinearFunctionForZeroStage3.apply(input, weight)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/home/yak/miniconda3/envs/dev/lib/python3.12/site-packages/torch/autograd/function.py", line 576, in apply
   return super().apply(*args, **kwargs)  # type: ignore[misc]
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           [rank0]: RuntimeError: Inference tensors cannot be saved for backward. To work around you can make a clone to get a normal tensor and use it in autograd.
```
when mixing train+eval with zero3 enabled.

After researching this issue I propose to replace `torch.inference_mode` with `torch.no_grad` which removes the problem.

This is what other users/frameworks use - validated with HF Trainer and got input from other users I know + SO.