### PR TITLE
bump v0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ Issues = "https://github.com/snowflakedb/ArcticTraining/issues"
 
 [project]
 name = "arctic_training"
-version = "0.0.6.dev0"
+version = "0.6.0"
 description = "Snowflake LLM training library"
 authors = [
     {author = "Michael Wyatt", email = "michael.wyatt@snowflake.com"},


### PR DESCRIPTION
As discussed on slack, the versioning we've been using doesn't make a lot of sense. We should have been using minor version bumps instead of patch version. Better late than never for a fix!

@sfc-gh-sbekman 