### PR TITLE
check `arctic_training_run` is in the `PATH` env var's pathes

### DIFF
--- a/arctic_training_cli.py
+++ b/arctic_training_cli.py
@@ -15,6 +15,7 @@
 
 
 import argparse
+import os
 import shutil
 import textwrap
 from pathlib import Path
@@ -54,7 +55,10 @@ def main():
     if not args.config.exists():
         raise FileNotFoundError(f"Config file {args.config} not found.")
 
-    exe_path = shutil.which("arctic_training_run")
+    runner_name = "arctic_training_run"
+    exe_path = shutil.which(runner_name)
+    if exe_path is None:
+        raise ValueError(f"can't find {runner_name} in paths of env var PATH={os.environ['PATH']}")
 
     ds_runner(
         [


### PR DESCRIPTION
while trying to launch AT under VSCode debugger, I have run into  `shutil.which("arctic_training_run")` silently returning `None` and then deepspeed failing to launch. This PR helps the user to know what's wrong.

I needed to edit `PATH` env var in debugger config (which wasn't matching my normal env)