### PR TITLE
another `torch_dtype => dtype` update

### DIFF
--- a/arctic_training/model/liger_factory.py
+++ b/arctic_training/model/liger_factory.py
@@ -47,7 +47,7 @@ class LigerModelFactory(HFModelFactory):
                 self.config.name_or_path,
                 config=model_config,
                 attn_implementation=self.config.attn_implementation,
-                torch_dtype=self.config.dtype.value,
+                dtype=self.config.dtype.value,
                 swiglu=swiglu,
             )
         except KeyError as e:


### PR DESCRIPTION
https://github.com/snowflakedb/ArcticTraining/pull/279 follow up - liger-kernel works as well (it doesn't use this key itself)