### PR TITLE
Expose scheduler-specific kwargs, such as min_lr_rate

### DIFF
--- a/arctic_training/scheduler/hf_factory.py
+++ b/arctic_training/scheduler/hf_factory.py
@@ -27,6 +27,7 @@ class HFSchedulerConfig(SchedulerConfig):
     name: str = "linear"
     warmup_ratio: HumanFloat = Field(default=0.1, ge=0.0, le=1.0)
     """ The fraction of total training steps used for linear learning rate warmup. """
+    scheduler_specific_kwargs: dict = {}
 
 
 class HFSchedulerFactory(SchedulerFactory):
@@ -39,5 +40,6 @@ class HFSchedulerFactory(SchedulerFactory):
             name=self.config.name,
             optimizer=optimizer,
             num_warmup_steps=num_warmup_steps * self.trainer.config.sequence_parallel_size,
+            scheduler_specific_kwargs=self.config.scheduler_specific_kwargs,
             num_training_steps=self.trainer.training_horizon * self.trainer.config.sequence_parallel_size,
         )

--- a/arctic_training/scheduler/hf_factory.py
+++ b/arctic_training/scheduler/hf_factory.py
@@ -27,7 +27,8 @@ class HFSchedulerConfig(SchedulerConfig):
     name: str = "linear"
     warmup_ratio: HumanFloat = Field(default=0.1, ge=0.0, le=1.0)
     """ The fraction of total training steps used for linear learning rate warmup. """
-    scheduler_specific_kwargs: dict = {}
+    scheduler_specific_kwargs: dict[str, Any] = Field(default_factory=dict)
+    """ Additional scheduler-specific keyword arguments. """
 
 
 class HFSchedulerFactory(SchedulerFactory):


### PR DESCRIPTION
Expose `scheduler_specific_kwargs`, such as `min_lr_rate` of the `cosine_with_min_lr` scheduler.

Enables config such as:

```
scheduler:
  name: cosine_with_min_lr
  warmup_ratio: 0.05
  scheduler_specific_kwargs:
    min_lr_rate: 0.1
```
