### PR TITLE
pynvml is deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     "peft",
     "psutil",
     "pydantic>=2.10",
-    "pynvml",
+    "nvidia-ml-py",
     "tabulate",
     "torch",
     "tqdm",


### PR DESCRIPTION
recent torch deprecated `pynvml` - wants `nvidia-ml-py` instead

```
/fsx/conda/envs/dev/lib/python3.12/site-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
```