### PR TITLE
Allow masking empty think tokens preventing the loss of thinking ability

### DIFF
--- a/arctic_training/data/sft_factory.py
+++ b/arctic_training/data/sft_factory.py
@@ -417,7 +417,8 @@ class SFTDataFactory(DataFactory):
     @staticmethod
     # this code is adpoted from https://github.com/huggingface/trl/issues/632 (user: Peter-Devine )
     def get_assistant_start_end_indices(
-        messages: List[Dict[str, str]], conversation_text: str,
+        messages: List[Dict[str, str]],
+        conversation_text: str,
         ignore_empty_think: bool = False,
     ) -> List[Tuple[int, int]]:
         return_indices = []


### PR DESCRIPTION
Allows enabling loss mask on empty <think> tags to retain thinking ability for SFT without CoT traces. This is analogous to `--loss_scale ignore_empty_think` in ms-swift. 