### PR TITLE
add python profiler

### DIFF
--- a/arctic_training/entrypoint.py
+++ b/arctic_training/entrypoint.py
@@ -71,7 +71,7 @@ def launch():
             train()
         else:
             # run profiler on rank 0
-            # XXX: how do we prent it from running on other nodes?
+            # XXX: how do we prevent it from running on other nodes?
             import cProfile
             from pstats import SortKey
 

--- a/arctic_training_cli.py
+++ b/arctic_training_cli.py
@@ -50,6 +50,16 @@ def main():
         help="Operation mode, 'process-data' will run the data processing pipeline.",
     )
     parser.add_argument("config", type=Path, help="ArticTraining config yaml file.")
+    parser.add_argument(
+        "--python_profile",
+        type=str,
+        choices=["tottime", "cumtime", "disable"],
+        default="disable",
+        help=(
+            "Train under Python profile. Sort results by tottime or cumtime. This is an experimental feature and the"
+            " API is likely to change"
+        ),
+    )
     args, deepspeed_args = parser.parse_known_args()
 
     if not args.config.exists():
@@ -68,6 +78,8 @@ def main():
             args.mode,
             "--config",
             str(args.config),
+            "--python_profile",
+            str(args.python_profile),
         ]
     )
 


### PR DESCRIPTION
This PR will allow you to add to the launcher `--python_profile <sortkey>`, which will run the code under `cProfile`, where sort keys are `tottime` or `cumtime` and then at the end of the run it will dump to stdout something like:

```
         2864954 function calls (2783834 primitive calls) in 6.499 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   515/18    0.002    0.000    3.857    0.214 parameter_offload.py:300(_post_forward_module_hook)
      290    0.001    0.000    2.951    0.010 autocast_mode.py:512(decorate_fwd)
       10    0.000    0.000    2.863    0.286 loss_utils.py:35(LigerForCausalLMLoss)
       10    0.000    0.000    2.862    0.286 loss_utils.py:9(fixed_fused_linear_cross_entropy)
       10    0.000    0.000    2.862    0.286 functional.py:55(liger_fused_linear_cross_entropy)
       10    0.000    0.000    2.667    0.267 fused_linear_cross_entropy.py:208(forward)
       10    1.122    0.112    2.667    0.267 fused_linear_cross_entropy.py:16(fused_linear_cross_entropy_forward)
       10    0.000    0.000    2.210    0.221 debug.py:133(get_mem_metrics)
```

I'm marking this API as experimental, since it's possible we might want to get the profile data into a file and then add per rank profile and more. So this is a very rough solution at the moment which I think will evolve.

Note we can't use yaml config here since it's too early in the game, hence the argparse API.
