### PR TITLE
Finish porting testing_utils.py

### DIFF
--- a/arctic_training/testing_utils.py
+++ b/arctic_training/testing_utils.py
@@ -493,7 +493,7 @@ class TestCasePlus(unittest.TestCase):
        - ``tests_dir`` - the directory of the ``tests`` test suite
        - ``data_dir`` - the directory of the ``tests/data`` test suite
        - ``repo_root_dir`` - the directory of the repository
-       - ``src_dir`` - the directory where the ``m4`` sub-dir resides (same as repo_root_dir in this case)
+       - ``src_dir`` - the directory where the ``arctic_training`` sub-dir resides (same as repo_root_dir in this case)
 
     * stringified paths---same as above but these return paths as strings, rather than ``pathlib`` objects:
 
@@ -568,15 +568,15 @@ class TestCasePlus(unittest.TestCase):
         self._test_file_dir = path.parents[0]
         for up in [1, 2, 3]:
             tmp_dir = path.parents[up]
-            if (tmp_dir / "m4").is_dir() and (tmp_dir / "tests").is_dir():
+            if (tmp_dir / "arctic_training").is_dir() and (tmp_dir / "tests").is_dir():
                 break
         if tmp_dir:
             self._repo_root_dir = tmp_dir
         else:
             raise ValueError(f"can't figure out the root of the repo from {self._test_file_path}")
         self._tests_dir = self._repo_root_dir / "tests"
-        self._data_dir = self._repo_root_dir / "tests" / "test_data"
-        self._src_dir = self._repo_root_dir  # m4 doesn't use "src/" prefix in the repo
+        self._data_dir = self._repo_root_dir / "tests" / "data"
+        self._src_dir = self._repo_root_dir
 
     @property
     def test_file_path(self):


### PR DESCRIPTION
it looks like I missed porting some repo layout nuances from the `m4` project this file originated from. This PR is fixing it.