### PR TITLE
Optimization: Better data filter and packing performance

### DIFF
--- a/arctic_training/data/source.py
+++ b/arctic_training/data/source.py
@@ -108,6 +108,10 @@ class DataSource(ABC, CallbackMixin, metaclass=RegistryMeta):
         dataset.save_to_disk(tmp_cache_path.as_posix())
         tmp_cache_path.rename(self.cache_path)
 
+        # NOTE: We use load_from_disk to get a disk-mmap backed dataset. This
+        # avoids the need to pickle data and send to subprocesses for filtering
+        # and data packing with a in-memory backed dataset and significantly
+        # improves performances.
         return load_from_disk(self.cache_path.as_posix())
 
     @property


### PR DESCRIPTION
During data processing, after samples have been tokenized they are cached to disk. We can take advantage of this and force the dataset backend to be `disk-mmap` rather than `in-memory` to improve performance of filtering and data packing steps that follow.

Example: `arctic_training process-data config.yaml --num_gpus 1`

Before (total time: `1251s`; filter+pack time: `970s`):
```
Tokenizing messages (num_proc=16): 116178/116178 [04:31<00:00, 427.21 examples/s]
Saving the dataset (13/13 shards): 116178/116178 [00:04<00:00, 27265.89 examples/s]
Filtering dataset by max length (num_proc=16): 116178/116178 [07:40<00:00, 252.47 examples/s]
Packing dataset (num_proc=16): 116178/116178 [08:30<00:00, 227.37 examples/s]
Saving the dataset (20/20 shards): 15357/15357 [00:06<00:00, 2417.73 examples/s]
```

After (total time: `342s`; filter+pack time: `67s` **← `>10X` speedup**):
```
Tokenizing messages (num_proc=16): 116178/116178 [04:24<00:00, 439.99 examples/s]
Saving the dataset (13/13 shards): 116178/116178 [00:04<00:00, 26616.98 examples/s]
Filtering dataset by max length (num_proc=16): 116178/116178 [00:27<00:00, 4207.39 examples/s]
Packing dataset (num_proc=16): 116178/116178 [00:40<00:00, 2840.04 examples/s]
Saving the dataset (20/20 shards): 15357/15357 [00:07<00:00, 2188.73 examples/s]
```
