### PR TITLE
move `wandb` log dir out of repo's root

### DIFF
--- a/arctic_training/trainer/trainer.py
+++ b/arctic_training/trainer/trainer.py
@@ -279,6 +279,8 @@ class Trainer(ABC, CallbackMixin, metaclass=RegistryMeta):
                 project=self.config.wandb.project,
                 name=self.config.wandb.name,
                 config=self.config.model_dump(),
+                # do not put `wandb` in the root of the repo as it conflicts with wandb package
+                dir=f"{self.config.logger.output_dir}/wandb",
             )
 
     def _set_seeds(self, seed: int) -> None:


### PR DESCRIPTION
 `wandb` log dir interferes with `isort` and `mypy` so by default put it under `logs/wandb`