### PR TITLE
allow hf model config overrides

### DIFF
--- a/arctic_training/config/model.py
+++ b/arctic_training/config/model.py
@@ -21,6 +21,7 @@ from typing import Type
 from typing import Union
 
 import peft
+from pydantic import Field
 from pydantic import field_validator
 
 from arctic_training.config.base import BaseConfig
@@ -52,6 +53,9 @@ class ModelConfig(BaseConfig):
 
     peft_config: Optional[Dict] = None
     """ Configuration for Parameter Efficient Fine Tuning. """
+
+    hf_config_kwargs: Dict = Field(default_factory=dict)
+    """ Optional kwargs to override in the HF model config object created by `AutoConfig.from_pretrained(model.name_or_path)` """
 
     @property
     def factory(self) -> Type["ModelFactory"]:

--- a/arctic_training/model/hf_factory.py
+++ b/arctic_training/model/hf_factory.py
@@ -29,6 +29,11 @@ class HFModelFactory(ModelFactory):
         return AutoConfig.from_pretrained(self.config.name_or_path)
 
     def create_model(self, model_config) -> PreTrainedModel:
+
+        # override hf model config if we have some custom config
+        for k, v in self.config.hf_config_kwargs.items():
+            setattr(model_config, k, v)
+
         return AutoModelForCausalLM.from_pretrained(
             self.config.name_or_path,
             config=model_config,

--- a/arctic_training/model/liger_factory.py
+++ b/arctic_training/model/liger_factory.py
@@ -42,6 +42,10 @@ class LigerModelFactory(HFModelFactory):
         swiglu = False if self.trainer.config.tiled_mlp_compute else True
         # XXX: it might be possible to combine the 2 in the future to benefit from the efficient liger swiglu kernel, but currently liger monkey patches the MLP class and thus we would have a race condition on who gets the override.
 
+        # override hf model config if we have some custom config
+        for k, v in self.config.hf_config_kwargs.items():
+            setattr(model_config, k, v)
+
         try:
             return AutoLigerKernelForCausalLM.from_pretrained(
                 self.config.name_or_path,


### PR DESCRIPTION
this feature allows a user to override the config distributed with the model on hf hub.

```
model:
  name_or_path: Qwen/Qwen3-Next-80B-A3B-Instruct
  hf_config_kwargs:
    num_hidden_layers: 24
```