### PR TITLE
rename fusedadam => fused_adam

### DIFF
--- a/arctic_training/optimizer/adam_factory.py
+++ b/arctic_training/optimizer/adam_factory.py
@@ -31,7 +31,7 @@ from arctic_training.optimizer.factory import OptimizerFactory
 
 
 class FusedAdamOptimizerFactory(OptimizerFactory):
-    name = "fusedadam"
+    name = "fused_adam"
 
     @staticmethod
     def get_optimizer_grouped_params(


### PR DESCRIPTION
for consistency with `cpu_adam`. it doesn't seem to be used anywhere explicitly so need for BC-support I think.

Fixing it since I'm going to create a subclass of it with a new name.