### PR TITLE
pin transformers until v5 becomes stable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
     "tabulate",
     "torch",
     "tqdm",
-    "transformers>=4.56", # torch_dtype deprecation
+    "transformers>=4.56,<5.0", # torch_dtype deprecation, 5.0 is unstable at the moment
     "wandb",
     "yq",
 ]


### PR DESCRIPTION
`transformers==5.x` isn't ready yet - lots of brekages, so pinning to `<5` for now