### PR TITLE
limit the batch size for `pack_dataset`

### DIFF
--- a/arctic_training/data/sft_factory.py
+++ b/arctic_training/data/sft_factory.py
@@ -332,6 +332,8 @@ def pack_dataset(self, dataset: DatasetType) -> DatasetType:
         dataset = repeat_dataset(dataset=dataset, max_length=self.config.max_length, num_proc=self.config.num_proc)
 
     batch_size = len(dataset) // self.config.num_proc + 1
+    # for huge datasets keep the bs to a sane size to avoid cpu-oom
+    batch_size = min(batch_size, 1e3)
     dataset = dataset.shuffle(seed=self.config.seed)
     dataset = dataset.map(
         lambda x: pack_sft_batch(


### PR DESCRIPTION
7M large dataset was leading to cpu-oom in `pack_dataset`, let's give the bs a sane upper bound.