### PR TITLE
Enhancement: Export WANDB environment variables with multinode execution

### DIFF
--- a/arctic_training_cli.py
+++ b/arctic_training_cli.py
@@ -22,7 +22,10 @@ from pathlib import Path
 
 import deepspeed
 from deepspeed.launcher.runner import main as ds_runner
-deepspeed.launcher.runner.EXPORT_ENVS = deepspeed.launcher.runner.EXPORT_ENVS + ["WANDB"] # Make sure WANDB_* env vars are passed for multinode execution
+
+deepspeed.launcher.runner.EXPORT_ENVS = deepspeed.launcher.runner.EXPORT_ENVS + [
+    "WANDB"
+]  # Make sure WANDB_* env vars are passed for multinode execution
 
 
 def main():


### PR DESCRIPTION
Important environment variables like `WANDB_API_KEY` or `WANDB_BASE_URL` will be dropped on the ground when using the deepspeed launcher for multinode. We can see this in action with `ds_ssh`:

```
❯ WANDB_API_KEY="MY_WANDB_API_KEY" ds_ssh "env | grep WANDB"     
/usr/bin/pdsh
hostfile=/job/hostfile
pdsh@node-0: 10.4.165.70: ssh exited with exit code 1
pdsh@node-1: 10.4.166.163: ssh exited with exit code 1
```

This change modifies `deepspeed.launcher.runner.EXPORT_ENVS` to also include any `WANDB*` environment variables.