### PR TITLE
get modal CI to run on PRs from forks

### DIFF
--- a/.github/workflows/gpu_unit_tests.yaml
+++ b/.github/workflows/gpu_unit_tests.yaml
@@ -18,7 +18,8 @@ on:
   pull_request_target:
     branches:
       - main
-      
+    paths-ignore:
+      - '**/README.md'
   push:
     branches:
       - main


### PR DESCRIPTION
The setup assumed all PRs come from AT's branches, but for forks there is an issue with passing secrets, so this PR is trying to sync with Deepspeed's workflow where the need is the same. https://github.com/deepspeedai/DeepSpeed/blob/master/.github/workflows/modal-torch-latest.yml