### PR TITLE
Relax dependency on `numba` for `[snowflake]`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ cortex = [
 
 snowflake = [
     "snowflake-ml-python>=1.21.0",
-    "numba>=0.63",  # Mitigate uv dependency resolution issue with snowflake-ml-python
+    "numba",  # Mitigate uv dependency resolution issue with snowflake-ml-python
 ]
 
 [project.scripts]


### PR DESCRIPTION
Relax dependency on `numba` for `[snowflake]` to avoid potential conflicts with other packages like `vllm`