### PR TITLE
Fix multi-node training with Ray launcher

### DIFF
--- a/arctic_training/launcher/ray_launcher.py
+++ b/arctic_training/launcher/ray_launcher.py
@@ -61,7 +61,7 @@ def _post_checkpoint_ray_save(trainer: Trainer) -> None:
         report_kwargs = dict(checkpoint=None)
 
         # Only upload checkpoint from rank 0
-        if train_context.get_world_rank() == 0:
+        if trainer.global_rank == 0:
             if any(engine.checkpoint_dir.resolve().is_relative_to(ray_checkpoint_path) for engine in active_engines):
                 # If any engine is writing to a subpath of the Ray checkpoint path,
                 # assume the user is handling checkpoint upload themselves and skip


### PR DESCRIPTION
Enhance Ray launcher for multi-node training in Snowflake ML Jobs

- Pass config file path to workers instead of in-memory dict to support code references and imports from recipe directories
- Add automatic Ray file sync configuration for non-shared storage environments using runtime_env working_dir
- Configure Ray storage path from Snowflake ML Job result path when available (MLRS_STAGE_RESULT_PATH)
- Implement Ray Train V2 checkpoint handling with NO_UPLOAD mode when checkpoints are already written to Ray storage paths

This improves compatibility with Snowflake ML Jobs and enables proper multi-node distributed training with Ray Train.