### PR TITLE
pynvml DGX Spark fix

### DIFF
--- a/arctic_training/debug.py
+++ b/arctic_training/debug.py
@@ -71,8 +71,12 @@ def get_nvml_mem():
             return 0
         pynvml_handle = pynvml.nvmlDeviceGetHandleByIndex(device_id)
         # pynvml.nvmlShutdown()
-    memory_info = pynvml.nvmlDeviceGetMemoryInfo(pynvml_handle)
-    return memory_info.used
+    try:
+        memory_info = pynvml.nvmlDeviceGetMemoryInfo(pynvml_handle)
+        return memory_info.used
+    except pynvml.NVMLError_NotSupported:
+        # DGX Spark fails here https://docs.nvidia.com/dgx/dgx-spark/known-issues.html#nvidia-smi-reports-memory-usage-not-supported
+        return 0
 
 
 def gc_empty_accelerator_cache():


### PR DESCRIPTION
DGX Spark can't read mem-usage via nvml https://docs.nvidia.com/dgx/dgx-spark/known-issues.html#nvidia-smi-reports-memory-usage-not-supported so have to catch this exception - `nvidia-smi` fails to read it too!

```
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 580.126.09             Driver Version: 580.126.09     CUDA Version: 13.0     |
+-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GB10                    On  |   0000000F:01:00.0 Off |                  N/A |
| N/A   36C    P8              3W /  N/A  | Not Supported          |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+

```