### PR TITLE
Fix: Unit tests conditionally create virtual environment

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -46,7 +46,9 @@ jobs:
       - name: Setup environment
         run: |
           pip install uv
-          uv venv
+          if [ ! -d .venv ]; then
+            uv venv
+          fi
           source .venv/bin/activate
           echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
           echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV


### PR DESCRIPTION
Check if venv exists before running `uv venv` to avoid this problem:
```
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at `/home/runner/work/ArcticTraining/ArcticTraining/.venv`. Use `--clear` to replace it
```