### PR TITLE
Fix incorrect validation for attention implementations

### DIFF
--- a/arctic_training/config/model.py
+++ b/arctic_training/config/model.py
@@ -101,5 +101,5 @@ class ModelConfig(BaseConfig):
                     f"flash_attention_3 requires the flash_attn_3 package."
                     " For FA3 build from the github source: git clone https://github.com/Dao-AILab/flash-attention;"
                     " cd flash-attention/hopper; pip install . --no-build-isolation --no-clean"
-                )                
+                )
         return value

--- a/arctic_training/config/model.py
+++ b/arctic_training/config/model.py
@@ -84,15 +84,22 @@ class ModelConfig(BaseConfig):
 
     @field_validator("attn_implementation", mode="after")
     def validate_attn_implementation(cls, value: str) -> str:
-        if value in ["flash_attention_2", "flash_attention_3"]:
+        if value == "flash_attention_2":
             try:
                 import flash_attn  # noqa: F401
             except (ImportError, ModuleNotFoundError):
                 raise ValueError(
-                    f"{value} requires the flash_attn package. Install with"
+                    "flash_attention_2 requires the flash_attn package. Install with"
                     " `pip install flash_attn`. Please refer to documentation at"
                     " https://huggingface.co/docs/transformers/perf_infer_gpu_one#flashattention-2."
+                )
+        elif value == "flash_attention_3":
+            try:
+                import flash_attn_3  # noqa: F401
+            except (ImportError, ModuleNotFoundError):
+                raise ValueError(
+                    f"flash_attention_3 requires the flash_attn_3 package."
                     " For FA3 build from the github source: git clone https://github.com/Dao-AILab/flash-attention;"
                     " cd flash-attention/hopper; pip install . --no-build-isolation --no-clean"
-                )
+                )                
         return value

--- a/arctic_training/config/model.py
+++ b/arctic_training/config/model.py
@@ -98,7 +98,7 @@ class ModelConfig(BaseConfig):
                 import flash_attn_3  # noqa: F401
             except (ImportError, ModuleNotFoundError):
                 raise ValueError(
-                    f"flash_attention_3 requires the flash_attn_3 package."
+                    "flash_attention_3 requires the flash_attn_3 package."
                     " For FA3 build from the github source: git clone https://github.com/Dao-AILab/flash-attention;"
                     " cd flash-attention/hopper; pip install . --no-build-isolation --no-clean"
                 )


### PR DESCRIPTION
This PR fixes an incorrect attention implementation validation to handle specific cases for 'flash_attention_2' and 'flash_attention_3'. Updated error messages for clarity.

Currently even if FA3 is installed, but not FA2, it'll fail to load.