### PR TITLE
Prevent activation_checkpoint_cpu_offload from silently no-op'ing on transformers >=5.0

### DIFF
--- a/arctic_training/model/hf_factory.py
+++ b/arctic_training/model/hf_factory.py
@@ -83,7 +83,12 @@ class HFModelFactory(ModelFactory):
             )
 
         if not self.config.disable_activation_checkpoint:
-            model.gradient_checkpointing_enable()
+            gc_kwargs = None
+            if self.trainer.config.activation_checkpoint_cpu_offload:
+                # CPU-offload monkey patch (see arctic_training.monkey_patches)
+                # only intercepts torch.utils.checkpoint's reentrant path.
+                gc_kwargs = {"use_reentrant": True}
+            model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=gc_kwargs)
             model = self.make_model_gradient_checkpointing_compatible(model)
 
         return model


### PR DESCRIPTION
## What
When `activation_checkpoint_cpu_offload` is enabled, force HF's `gradient_checkpointing_enable` to use `use_reentrant=True`.
## Why
The CPU-offload activation checkpointing in `arctic_training.monkey_patches` replaces `torch.utils.checkpoint.CheckpointFunction`, which is only used by the **reentrant** code path of `torch.utils.checkpoint.checkpoint`. The non-reentrant path goes through `_checkpoint_without_reentrant_generator` + `saved_tensors_hooks` and never touches `CheckpointFunction`, so the monkey patch becomes a silent no-op there.

In current `transformers` (4.x), `model.gradient_checkpointing_enable()` with no kwargs defaults to `use_reentrant=True`, so this happens to work. Starting with `transformers` v5.0.0 ([huggingface/transformers#43203], merged Jan 2026), the default flips to `use_reentrant=False`. Once we bump the upper pin past `<5.0.0`, users setting `activation_checkpoint_cpu_offload: true` would get **no offloading at all** — long-sequence runs would OOM with no error or warning to indicate why.

**Note: tactical fix.** The proper long-term solution is to replace the `CheckpointFunction` monkey patch with a `saved_tensors_hooks`-based implementation (see torchtune reference in `monkey_patches.py`), which would work regardless of `use_reentrant`. Out of scope here.
